### PR TITLE
ci: add kurtosis devnet test

### DIFF
--- a/.github/workflows/kurtosis_devnet.yaml
+++ b/.github/workflows/kurtosis_devnet.yaml
@@ -19,4 +19,9 @@ jobs:
           version: ${{ env.MISE_VERSION }}
           experimental: true
       - run: just run-kurtosis-devnet
+      # We build the client here because `just run-client-native-against-devnet`
+      # first polls op-geth for a first finalized block, which takes a few minutes,
+      # and only after that runs `cargo run` which then builds the client, and takes another
+      # few minutes. Better to build here while waiting for first l2 block to finalize.
+      - run: just build-native
       - run: just run-client-native-against-devnet

--- a/.github/workflows/kurtosis_devnet.yaml
+++ b/.github/workflows/kurtosis_devnet.yaml
@@ -24,4 +24,7 @@ jobs:
       # and only after that runs `cargo run` which then builds the client, and takes another
       # few minutes. Better to build here while waiting for first l2 block to finalize.
       - run: just build-native
+      # We run this explicitly here even though its run implicitly as a dependency of `run-client-native-against-devnet`
+      # just so that we can see the breakdown timing requirements for each step.
+      - run: just _kurtosis_wait_for_first_l2_finalized_block
       - run: just run-client-native-against-devnet

--- a/.github/workflows/kurtosis_devnet.yaml
+++ b/.github/workflows/kurtosis_devnet.yaml
@@ -19,6 +19,7 @@ jobs:
           version: ${{ env.MISE_VERSION }}
           experimental: true
       - run: just run-kurtosis-devnet
+      - uses: Swatinem/rust-cache@v2 # cache for `just build-native`
       # We build the client here because `just run-client-native-against-devnet`
       # first polls op-geth for a first finalized block, which takes a few minutes,
       # and only after that runs `cargo run` which then builds the client, and takes another

--- a/.github/workflows/kurtosis_devnet.yaml
+++ b/.github/workflows/kurtosis_devnet.yaml
@@ -1,0 +1,22 @@
+name: Kurtosis Devnet
+
+on:
+  push:
+    branches: [master]
+  merge_group:
+  pull_request:
+
+env:
+  MISE_VERSION: 2024.12.14
+
+jobs:
+  kurtosis_devnet:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v2
+        with:
+          version: ${{ env.MISE_VERSION }}
+          experimental: true
+      - run: just run-kurtosis-devnet
+      - run: just run-client-native-against-devnet

--- a/justfile
+++ b/justfile
@@ -45,6 +45,7 @@ _download-rollup-config-from-kurtosis enclave='eigenda-devnet':
 [group('local-env')]
 _kurtosis_wait_for_first_l2_finalized_block:
   #!/usr/bin/env bash
+  FOUNDRY_DISABLE_NIGHTLY_WARNING=true
   L2_RPC=$(kurtosis port print eigenda-devnet op-el-1-op-geth-op-node-op-kurtosis rpc)
   echo "Waiting for first finalized block on L2 chain at $L2_RPC"
   while true; do

--- a/justfile
+++ b/justfile
@@ -30,6 +30,9 @@ download-srs:
         echo "SRS file resources/g1.point already exists, skipping download"
     fi
 
+# This target runs as a prerequisite to `run-client-native-against-devnet` target.
+# The client assumes that rollup.json is present in the current working directory.
+# This target downloads the rollup config from the op-node running in the kurtosis enclave.
 [group('local-env')]
 _download-rollup-config-from-kurtosis enclave='eigenda-devnet':
   #!/usr/bin/env bash
@@ -37,9 +40,25 @@ _download-rollup-config-from-kurtosis enclave='eigenda-devnet':
   echo "Downloading rollup config from kurtosis op-node at $ROLLUP_NODE_RPC"
   cast rpc "optimism_rollupConfig" --rpc-url $ROLLUP_NODE_RPC | jq > rollup.json
 
+# `run-client-native-against-devnet` requires a finalized L2 block before it can run.
+# In CI we thus run this command before running the client.
+[group('local-env')]
+_kurtosis_wait_for_first_l2_finalized_block:
+  #!/usr/bin/env bash
+  L2_RPC=$(kurtosis port print eigenda-devnet op-el-1-op-geth-op-node-op-kurtosis rpc)
+  echo "Waiting for first finalized block on L2 chain at $L2_RPC"
+  while true; do
+    BLOCK_NUMBER=$(cast block finalized --json --rpc-url $L2_RPC | jq -r .number | cast 2d)
+    if [ $BLOCK_NUMBER -ne 0 ]; then
+      echo "First finalized block found: $BLOCK_NUMBER"
+      break
+    fi
+    sleep 5
+  done
+
 # Run the client program natively with the host program attached, against the op-devnet.
 [group('local-env')]
-run-client-native-against-devnet verbosity='' block_number='' rollup_config_path='rollup.json' enclave='eigenda-devnet': (download-srs) (_download-rollup-config-from-kurtosis)
+run-client-native-against-devnet verbosity='' block_number='' rollup_config_path='rollup.json' enclave='eigenda-devnet': (download-srs) (_download-rollup-config-from-kurtosis) (_kurtosis_wait_for_first_l2_finalized_block)
   #!/usr/bin/env bash
   L1_RPC="http://$(kurtosis port print {{enclave}} el-1-geth-teku rpc)"
   L1_BEACON_RPC="$(kurtosis port print {{enclave}} cl-1-teku-geth http)"
@@ -67,6 +86,12 @@ run-client-native-against-devnet verbosity='' block_number='' rollup_config_path
 [group('local-env')]
 run-kurtosis-devnet ENCLAVE_NAME="eigenda-devnet" ARGS_FILE="kurtosis_params.yaml":
   kurtosis run --enclave {{ENCLAVE_NAME}} github.com/ethpandaops/optimism-package --args-file {{ARGS_FILE}} --image-download always
+
+# If you have run run-kurtosis-devnet recently, which always downloads all images,
+# then it is safe to run this command, which skill use cached images instead, and is thus faster.
+[group('local-env')]
+run-kurtosis-devnet-with-cached-images ENCLAVE_NAME="eigenda-devnet" ARGS_FILE="kurtosis_params.yaml":
+  kurtosis run --enclave {{ENCLAVE_NAME}} github.com/ethpandaops/optimism-package --args-file {{ARGS_FILE}}
 
 ############################### STYLE ###############################
 

--- a/kurtosis_params.yaml
+++ b/kurtosis_params.yaml
@@ -22,7 +22,9 @@ ethereum_package:
       el_type: geth
 optimism_package:
   observability:
-    enabled: false
+    # Unfortunately can't be disabled, see https://github.com/ethpandaops/optimism-package/issues/221
+    # Would be nice to speed up CI...
+    enabled: true
   altda_deploy_config:
     da_bond_size: 0
     da_challenge_window: 16

--- a/kurtosis_params.yaml
+++ b/kurtosis_params.yaml
@@ -13,8 +13,16 @@ ethereum_package:
     preset: minimal
   participants:
     - cl_type: teku
+      # 25.4.1 (current latest) is broken because optimism-package uses an old version of ethereum-package,
+      # which doesn't support 
+      # See https://github.com/ethpandaops/optimism-package/blob/c993cd0b9716fb063c1e514e19374e27e1b10b3c/kurtosis.yml#L6
+      # Once this gets updated, we can revert back to using latest teku.
+      # See https://github.com/ethpandaops/ethereum-package/issues/974 for more details.
+      cl_image: consensys/teku:25.4.0
       el_type: geth
 optimism_package:
+  observability:
+    enabled: false
   altda_deploy_config:
     da_bond_size: 0
     da_challenge_window: 16

--- a/mise.toml
+++ b/mise.toml
@@ -1,10 +1,29 @@
 [tools]
-cargo = "latest"
-cast = { version = "latest", exe = "cast" }
+
+# Rust dependencies
+# TODO: not sure what's the best way to manage these versions yet...
+# This version should ideally be the same as the rust-version in Cargo.toml.
+# I think mise also uses rust-toolchain.toml by default if it exists, so perhaps
+# we could use that instead...? Need to do some research on this.
+cargo = "0.87.1"
+rust = "1.83"
+
+# Foundry dependencies
+# Foundry is a special case because it supplies multiple binaries at the same
+# GitHub release, so we need to use the aliasing trick to get mise to not error
+# The git ref here should be on the `stable` branch.
+# Updated to use the specific nightly build
+forge = "nightly-654c8f01721e43dbc8a53c7a3b022548cb82b2f9"
+cast = "nightly-654c8f01721e43dbc8a53c7a3b022548cb82b2f9"
+anvil = "nightly-654c8f01721e43dbc8a53c7a3b022548cb82b2f9"
+
+
+# Miscellaneous dependencies
 just = "latest"
-rust = "latest"
-# Warning: version might need to be pinned manually.
-# It needs to be the same version as that used by the kurtosis engine that
-# was used to start the optimism kurtosis devnet.
-kurtosis = { version = "latest", exe = "kurtosis" }
 jq = "latest"
+kurtosis = "1.6.0"
+
+[alias]
+forge = "ubi:foundry-rs/foundry[exe=forge]"
+cast = "ubi:foundry-rs/foundry[exe=cast]"
+anvil = "ubi:foundry-rs/foundry[exe=anvil]"

--- a/mise.toml
+++ b/mise.toml
@@ -5,25 +5,21 @@
 # This version should ideally be the same as the rust-version in Cargo.toml.
 # I think mise also uses rust-toolchain.toml by default if it exists, so perhaps
 # we could use that instead...? Need to do some research on this.
-cargo = "0.87.1"
 rust = "1.83"
 
 # Foundry dependencies
-# Foundry is a special case because it supplies multiple binaries at the same
-# GitHub release, so we need to use the aliasing trick to get mise to not error
-# The git ref here should be on the `stable` branch.
-# Updated to use the specific nightly build
 forge = "nightly-654c8f01721e43dbc8a53c7a3b022548cb82b2f9"
 cast = "nightly-654c8f01721e43dbc8a53c7a3b022548cb82b2f9"
 anvil = "nightly-654c8f01721e43dbc8a53c7a3b022548cb82b2f9"
 
 
 # Miscellaneous dependencies
-just = "latest"
 jq = "latest"
+just = "latest"
 kurtosis = "1.6.0"
 
 [alias]
 forge = "ubi:foundry-rs/foundry[exe=forge]"
 cast = "ubi:foundry-rs/foundry[exe=cast]"
 anvil = "ubi:foundry-rs/foundry[exe=anvil]"
+kurtosis = "ubi:kurtosis-tech/kurtosis-cli-release-artifacts[exe=kurtosis]"


### PR DESCRIPTION
This PR follows https://github.com/Layr-Labs/hokulea/pull/53
We add the (now reproducible) justfile commands to start a devnet and run the native-client against it to a github action, to make sure no regressions are caused that would break them in the future.

Also fixes issue with latest op-package (fixed by pinning teku image).
