### PR TITLE
chore: add rust-toolchain.toml with channel = 1.85

### DIFF
--- a/justfile
+++ b/justfile
@@ -36,6 +36,7 @@ download-srs:
 [group('local-env')]
 _download-rollup-config-from-kurtosis enclave='eigenda-devnet':
   #!/usr/bin/env bash
+  export FOUNDRY_DISABLE_NIGHTLY_WARNING=true
   ROLLUP_NODE_RPC=$(kurtosis port print {{enclave}} op-cl-1-op-node-op-geth-op-kurtosis http)
   echo "Downloading rollup config from kurtosis op-node at $ROLLUP_NODE_RPC"
   cast rpc "optimism_rollupConfig" --rpc-url $ROLLUP_NODE_RPC | jq > rollup.json
@@ -45,15 +46,15 @@ _download-rollup-config-from-kurtosis enclave='eigenda-devnet':
 [group('local-env')]
 _kurtosis_wait_for_first_l2_finalized_block:
   #!/usr/bin/env bash
-  FOUNDRY_DISABLE_NIGHTLY_WARNING=true
+  export FOUNDRY_DISABLE_NIGHTLY_WARNING=true
   L2_RPC=$(kurtosis port print eigenda-devnet op-el-1-op-geth-op-node-op-kurtosis rpc)
-  echo "Waiting for first finalized block on L2 chain at $L2_RPC"
   while true; do
     BLOCK_NUMBER=$(cast block finalized --json --rpc-url $L2_RPC | jq -r .number | cast 2d)
     if [ $BLOCK_NUMBER -ne 0 ]; then
       echo "First finalized block found: $BLOCK_NUMBER"
       break
     fi
+    echo "Waiting for first finalized block on L2 chain at $L2_RPC"
     sleep 5
   done
 
@@ -61,6 +62,7 @@ _kurtosis_wait_for_first_l2_finalized_block:
 [group('local-env')]
 run-client-native-against-devnet verbosity='' block_number='' rollup_config_path='rollup.json' enclave='eigenda-devnet': (download-srs) (_download-rollup-config-from-kurtosis) (_kurtosis_wait_for_first_l2_finalized_block)
   #!/usr/bin/env bash
+  export FOUNDRY_DISABLE_NIGHTLY_WARNING=true
   L1_RPC="http://$(kurtosis port print {{enclave}} el-1-geth-teku rpc)"
   L1_BEACON_RPC="$(kurtosis port print {{enclave}} cl-1-teku-geth http)"
   L2_RPC="$(kurtosis port print {{enclave}} op-el-1-op-geth-op-node-op-kurtosis rpc)"

--- a/mise.toml
+++ b/mise.toml
@@ -1,12 +1,5 @@
 [tools]
 
-# Rust dependencies
-# TODO: not sure what's the best way to manage these versions yet...
-# This version should ideally be the same as the rust-version in Cargo.toml.
-# I think mise also uses rust-toolchain.toml by default if it exists, so perhaps
-# we could use that instead...? Need to do some research on this.
-rust = "1.83"
-
 # Foundry dependencies
 forge = "nightly-654c8f01721e43dbc8a53c7a3b022548cb82b2f9"
 cast = "nightly-654c8f01721e43dbc8a53c7a3b022548cb82b2f9"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = '1.85'
+profile = 'minimal'
+components = ['clippy', 'rustfmt']
+targets = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin", "i686-unknown-linux-gnu"]


### PR DESCRIPTION
This is needed to make rust-analyzer work properly with the latest kona branches, which we will soon be using (see https://github.com/Layr-Labs/hokulea/pull/56)

kona recently bumped their MSRV to 1.85, so our toolchain also needs to support this. We should probably also add an MSRV, but I think that should be done in the PR that rebases actually requires this new MSRV (namely the one using the newest version of kona).