### PR TITLE
chore: fix+refactor justfile to allow building/running asterisc

### DIFF
--- a/.github/workflows/kurtosis_devnet.yaml
+++ b/.github/workflows/kurtosis_devnet.yaml
@@ -28,4 +28,5 @@ jobs:
       # We run this explicitly here even though its run implicitly as a dependency of `run-client-native-against-devnet`
       # just so that we can see the breakdown timing requirements for each step.
       - run: just _kurtosis_wait_for_first_l2_finalized_block
-      - run: just run-client-native-against-devnet
+      - run: just run-client-against-devnet 'native' 
+      # TODO: we should also run the asterisc/cannon client once it works

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,12 @@
 resolver = "2"
 members = ["bin/*", "crates/*"]
 
+[profile.release-client-lto]
+inherits = "release"
+panic = "abort"
+codegen-units = 1
+lto = "fat"
+
 [workspace.dependencies]
 kona-client = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.16" }
 kona-host = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.16" }

--- a/README.md
+++ b/README.md
@@ -6,22 +6,40 @@ Below is the dependency graph between hokulea and kona crates:
 <!-- Run `just generate-deps-graphviz` to regenerate/update this diagram -->
 ![](./generated/dependencies_graph.png)
 
-### Dependencies
+## Dependencies
 
 We use mise to track and manage dependencies. Please first [install mise](https://mise.jdx.dev/getting-started.html), and then run `mise install` to install the dependencies.
 
-### SRS points
+## SRS points
 Hokulea's proving client currently computes a challenge proof that validates the correctness of the eigenda blob against the provided kzg commitment. Such computation requires the proving client to have access to sufficient KZG G1 SRS points. Currently the SRS points are (hardcoded) assumed to be located at `resources/g1.point`. You can download the SRS points to that location by running `just download-srs`, which downloads the `g1.point` file from the [eigenda repo](https://github.com/Layr-Labs/eigenda-proxy/tree/main/resources).
 
-### Local Manual Testing
+## Local Manual Testing
 
 We use kurtosis to start an [optimism-package](https://github.com/ethpandaops/optimism-package/tree/main) devnet, and run the hokulea host and client against it.
 
 ```bash
 just run-kurtosis-devnet
+```
+
+### Running the native client
+
+```bash
 # Before running the client, it will download the needed g1.point SRS file
 # and the rollup.json config file.
-just run-client-native-against-devnet
+just run-client-against-devnet 'native'
+```
+
+### Running on Asterisc
+
+> :Warning: Building the client to run on asterisc currently doesn't work. We are spending most of our current effort on zk approaches instead, but we will eventually fix this.
+
+You will first need to build the client against the correct arch. Run
+```bash
+just build-client-for-asterisc
+```
+Then you can run
+```bash
+just run-client-against-devnet 'asterisc'
 ```
 
 ![](./hokulea.jpeg)

--- a/bin/client/justfile
+++ b/bin/client/justfile
@@ -4,67 +4,8 @@ set fallback := true
 default:
   @just --list
 
-# Run the client program on asterisc with the host in detached server mode.
-run-client-asterisc block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc eigenda_proxy_rpc verbosity='':
-  #!/usr/bin/env bash
-
-  L1_NODE_ADDRESS="{{l1_rpc}}"
-  L1_BEACON_ADDRESS="{{l1_beacon_rpc}}"
-  L2_NODE_ADDRESS="{{l2_rpc}}"
-  OP_NODE_ADDRESS="{{rollup_node_rpc}}"
-  EIGENDA_PROXY_ADDRESS="{{eigenda_proxy_rpc}}"
-
-  HOST_BIN_PATH="./target/release/kona-host"
-  CLIENT_BIN_PATH="./target/riscv64gc-unknown-none-elf/release-client-lto/kona"
-  STATE_PATH="./state.bin.gz"
-
-  CLAIMED_L2_BLOCK_NUMBER={{block_number}}
-  echo "Fetching configuration for block #$CLAIMED_L2_BLOCK_NUMBER..."
-
-  # Get output root for block
-  CLAIMED_L2_OUTPUT_ROOT=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $CLAIMED_L2_BLOCK_NUMBER) | jq -r .outputRoot)
-
-  # Get the info for the previous block
-  AGREED_L2_OUTPUT_ROOT=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $((CLAIMED_L2_BLOCK_NUMBER - 1))) | jq -r .outputRoot)
-  AGREED_L2_HEAD_HASH=$(cast block --rpc-url $L2_NODE_ADDRESS $((CLAIMED_L2_BLOCK_NUMBER - 1)) --json | jq -r .hash)
-  L1_ORIGIN_NUM=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $((CLAIMED_L2_BLOCK_NUMBER - 1))) | jq -r .blockRef.l1origin.number)
-  L1_HEAD=$(cast block --rpc-url $L1_NODE_ADDRESS $((L1_ORIGIN_NUM + 30)) --json | jq -r .hash)
-  L2_CHAIN_ID=$(cast chain-id --rpc-url $L2_NODE_ADDRESS)
-
-  # Move to the workspace root
-  cd $(git rev-parse --show-toplevel)
-
-  echo "Building client program for RISC-V target..."
-  just build-asterisc --bin kona --profile release-client-lto
-
-  echo "Loading client program into Asterisc state format..."
-  asterisc load-elf --path=$CLIENT_BIN_PATH
-
-  echo "Building host program for native target..."
-  cargo build --bin kona-host --release
-
-  echo "Running asterisc"
-  asterisc run \
-    --info-at '%10000000' \
-    --proof-at never \
-    --input $STATE_PATH \
-    -- \
-    $HOST_BIN_PATH \
-    --l1-head $L1_HEAD \
-    --agreed-l2-head-hash $AGREED_L2_HEAD_HASH \
-    --claimed-l2-output-root $CLAIMED_L2_OUTPUT_ROOT \
-    --agreed-l2-output-root $AGREED_L2_OUTPUT_ROOT \
-    --claimed-l2-block-number $CLAIMED_L2_BLOCK_NUMBER \
-    --l2-chain-id $L2_CHAIN_ID \
-    --l1-node-address $L1_NODE_ADDRESS \
-    --l1-beacon-address $L1_BEACON_ADDRESS \
-    --l2-node-address $L2_NODE_ADDRESS \
-    --server \
-    --data-dir ./data \
-    {{verbosity}}
-
-# Run the client program natively with the host program attached.
-run-client-native block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc eigenda_proxy_rpc rollup_config_path='' verbosity='':
+# Run the client program, either natively or on asterisc, depending on the 'native_or_asterisc' argument.
+run-client block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc eigenda_proxy_rpc native_or_asterisc='native' rollup_config_path='' verbosity='':
   #!/usr/bin/env bash
   set -o errexit -o nounset -o pipefail
 
@@ -73,6 +14,7 @@ run-client-native block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc eigen
   L2_NODE_ADDRESS="{{l2_rpc}}"
   OP_NODE_ADDRESS="{{rollup_node_rpc}}"
   EIGENDA_PROXY_ADDRESS="{{eigenda_proxy_rpc}}"
+  NATIVE_OR_ASTERISC="{{native_or_asterisc}}"
 
   L2_CHAIN_ID=$(cast chain-id --rpc-url $L2_NODE_ADDRESS)
   if [ -z "{{rollup_config_path}}" ]; then
@@ -99,21 +41,57 @@ run-client-native block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc eigen
   rm -rf ./data
   mkdir ./data
 
-  echo "Running host program with native client program..."
-  cargo r --bin hokulea-host-bin  -- \
-    --l1-head $L1_HEAD \
-    --agreed-l2-head-hash $AGREED_L2_HEAD_HASH \
-    --claimed-l2-output-root $CLAIMED_L2_OUTPUT_ROOT \
-    --agreed-l2-output-root $AGREED_L2_OUTPUT_ROOT \
-    --claimed-l2-block-number $CLAIMED_L2_BLOCK_NUMBER \
-    --l1-node-address $L1_NODE_ADDRESS \
-    --l1-beacon-address $L1_BEACON_ADDRESS \
-    --l2-node-address $L2_NODE_ADDRESS \
-    --eigenda-proxy-address $EIGENDA_PROXY_ADDRESS \
-    --native \
-    --data-dir ./data \
-    $CHAIN_ID_OR_ROLLUP_CONFIG_ARG \
-    {{verbosity}}
+  if [ "$NATIVE_OR_ASTERISC" = "native" ]; then
+    echo "Running host program with native client program..."
+    cargo r --bin hokulea-host-bin  -- \
+      --l1-head $L1_HEAD \
+      --agreed-l2-head-hash $AGREED_L2_HEAD_HASH \
+      --claimed-l2-output-root $CLAIMED_L2_OUTPUT_ROOT \
+      --agreed-l2-output-root $AGREED_L2_OUTPUT_ROOT \
+      --claimed-l2-block-number $CLAIMED_L2_BLOCK_NUMBER \
+      --l1-node-address $L1_NODE_ADDRESS \
+      --l1-beacon-address $L1_BEACON_ADDRESS \
+      --l2-node-address $L2_NODE_ADDRESS \
+      --eigenda-proxy-address $EIGENDA_PROXY_ADDRESS \
+      --native \
+      --data-dir ./data \
+      $CHAIN_ID_OR_ROLLUP_CONFIG_ARG \
+      {{verbosity}}
+  elif [ "$NATIVE_OR_ASTERISC" = "asterisc" ]; then
+    HOST_BIN_PATH="./target/release/kona-host"
+    CLIENT_BIN_PATH="./target/riscv64gc-unknown-none-elf/release-client-lto/kona"
+    STATE_PATH="./state.bin.gz"
+
+    echo "Building hokulea host program for RISC-V target..."
+    just build-asterisc-host
+    echo "Loading host program into Asterisc state format..."
+    asterisc load-elf --path=$CLIENT_BIN_PATH
+    echo "Building host program for native target..."
+    cargo build --bin kona-host --release
+
+    echo "Running asterisc"
+    asterisc run \
+      --info-at '%10000000' \
+      --proof-at never \
+      --input $STATE_PATH \
+      -- \
+      $HOST_BIN_PATH \
+      --l1-head $L1_HEAD \
+      --agreed-l2-head-hash $AGREED_L2_HEAD_HASH \
+      --claimed-l2-output-root $CLAIMED_L2_OUTPUT_ROOT \
+      --agreed-l2-output-root $AGREED_L2_OUTPUT_ROOT \
+      --claimed-l2-block-number $CLAIMED_L2_BLOCK_NUMBER \
+      --l2-chain-id $L2_CHAIN_ID \
+      --l1-node-address $L1_NODE_ADDRESS \
+      --l1-beacon-address $L1_BEACON_ADDRESS \
+      --l2-node-address $L2_NODE_ADDRESS \
+      --server \
+      --data-dir ./data \
+      {{verbosity}}
+  else
+    echo "Unknown value for NATIVE_OR_ASTERISC: $NATIVE_OR_ASTERISC"
+    exit 1
+  fi
 
 # Run the client program natively with the host program attached, in offline mode.
 run-client-native-offline block_number l2_claim l2_output_root l2_head l1_head l2_chain_id verbosity='':

--- a/justfile
+++ b/justfile
@@ -7,14 +7,24 @@ default:
 ############################### BUILD ###############################
 
 # Build the workspace for all available targets
-alias b := build
+alias b := build-all
 [group('build')]
-build: build-native
+build-all: build-native build-client-for-asterisc
 
 # Build for the native target
 [group('build')]
 build-native *args='':
   cargo build --workspace $@
+
+# Build `hokulea-client` for the `asterisc` target.
+[group('build')]
+build-client-for-asterisc:
+  docker run \
+    --rm \
+    -v `pwd`/:/workdir \
+    -w="/workdir" \
+    ghcr.io/op-rs/kona/asterisc-builder:0.1.0 \
+    cargo build -Zbuild-std=core,alloc -p hokulea-client-bin --bin hokulea-client-bin --profile release-client-lto --no-default-features
 
 ############################### LOCAL DEVNET ###############################
 
@@ -34,20 +44,24 @@ download-srs:
 # The client assumes that rollup.json is present in the current working directory.
 # This target downloads the rollup config from the op-node running in the kurtosis enclave.
 [group('local-env')]
-_download-rollup-config-from-kurtosis enclave='eigenda-devnet':
+_download-rollup-config-from-kurtosis enclave='eigenda-devnet' chain_id='2151908':
   #!/usr/bin/env bash
+  set -o pipefail -o errexit -o nounset
   export FOUNDRY_DISABLE_NIGHTLY_WARNING=true
-  ROLLUP_NODE_RPC=$(kurtosis port print {{enclave}} op-cl-1-op-node-op-geth-op-kurtosis http)
+
+  ROLLUP_NODE_RPC=$(kurtosis port print {{enclave}} op-cl-{{chain_id}}-1-op-node-op-geth-op-kurtosis http)
   echo "Downloading rollup config from kurtosis op-node at $ROLLUP_NODE_RPC"
   cast rpc "optimism_rollupConfig" --rpc-url $ROLLUP_NODE_RPC | jq > rollup.json
 
 # `run-client-native-against-devnet` requires a finalized L2 block before it can run.
 # In CI we thus run this command before running the client.
 [group('local-env')]
-_kurtosis_wait_for_first_l2_finalized_block:
+_kurtosis_wait_for_first_l2_finalized_block chain_id='2151908':
   #!/usr/bin/env bash
+  set -o pipefail -o errexit -o nounset
   export FOUNDRY_DISABLE_NIGHTLY_WARNING=true
-  L2_RPC=$(kurtosis port print eigenda-devnet op-el-1-op-geth-op-node-op-kurtosis rpc)
+
+  L2_RPC=$(kurtosis port print eigenda-devnet op-el-{{chain_id}}-1-op-geth-op-node-op-kurtosis rpc)
   while true; do
     BLOCK_NUMBER=$(cast block finalized --json --rpc-url $L2_RPC | jq -r .number | cast 2d)
     if [ $BLOCK_NUMBER -ne 0 ]; then
@@ -60,13 +74,15 @@ _kurtosis_wait_for_first_l2_finalized_block:
 
 # Run the client program natively with the host program attached, against the op-devnet.
 [group('local-env')]
-run-client-native-against-devnet verbosity='' block_number='' rollup_config_path='rollup.json' enclave='eigenda-devnet': (download-srs) (_download-rollup-config-from-kurtosis) (_kurtosis_wait_for_first_l2_finalized_block)
+run-client-against-devnet native_or_asterisc='native' verbosity='' block_number='' rollup_config_path='rollup.json' enclave='eigenda-devnet' chain_id='2151908': (download-srs) (_download-rollup-config-from-kurtosis) (_kurtosis_wait_for_first_l2_finalized_block)
   #!/usr/bin/env bash
+  set -o errexit -o nounset -o pipefail
   export FOUNDRY_DISABLE_NIGHTLY_WARNING=true
+
   L1_RPC="http://$(kurtosis port print {{enclave}} el-1-geth-teku rpc)"
   L1_BEACON_RPC="$(kurtosis port print {{enclave}} cl-1-teku-geth http)"
-  L2_RPC="$(kurtosis port print {{enclave}} op-el-1-op-geth-op-node-op-kurtosis rpc)"
-  ROLLUP_NODE_RPC="$(kurtosis port print {{enclave}} op-cl-1-op-node-op-geth-op-kurtosis http)"
+  L2_RPC="$(kurtosis port print {{enclave}} op-el-{{chain_id}}-1-op-geth-op-node-op-kurtosis rpc)"
+  ROLLUP_NODE_RPC="$(kurtosis port print {{enclave}} op-cl-{{chain_id}}-1-op-node-op-geth-op-kurtosis http)"
   EIGENDA_PROXY_RPC="$(kurtosis port print {{enclave}} da-server-op-kurtosis http)"
   ROLLUP_CONFIG_PATH="$(realpath {{rollup_config_path}})"
 
@@ -81,10 +97,11 @@ run-client-native-against-devnet verbosity='' block_number='' rollup_config_path
   else
     BLOCK_NUMBER={{block_number}}
   fi
+
   set -x
-  just --justfile bin/client/justfile run-client-native $BLOCK_NUMBER \
+  just --justfile bin/client/justfile run-client $BLOCK_NUMBER \
     $L1_RPC $L1_BEACON_RPC $L2_RPC $ROLLUP_NODE_RPC $EIGENDA_PROXY_RPC \
-    $ROLLUP_CONFIG_PATH {{verbosity}}
+    {{native_or_asterisc}} $ROLLUP_CONFIG_PATH {{verbosity}}
 
 [group('local-env')]
 run-kurtosis-devnet ENCLAVE_NAME="eigenda-devnet" ARGS_FILE="kurtosis_params.yaml":


### PR DESCRIPTION
Previously asterisc command was just not working, calling justfile targets that didn't exist. Fixed that.
Now it at least attempst to build. The build fails because of weird dependency hell type of errors. Should fix in a subsequent PR since this is not a priority atm.

Also refactored such that we have a single justfile run-client target which can run against cannor or asterisc depending on an argument.