### PR TITLE
fix host bug that accept 500 error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4051,7 +4051,6 @@ name = "hokulea-host-bin"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives 1.1.0",
- "alloy-rlp",
  "anyhow",
  "async-trait",
  "clap",

--- a/bin/host/Cargo.toml
+++ b/bin/host/Cargo.toml
@@ -18,7 +18,6 @@ kona-cli.workspace = true
 kona-client.workspace = true
 
 # Alloy
-alloy-rlp.workspace = true
 alloy-primitives = { workspace = true, features = ["serde"] }
 
 # General

--- a/bin/host/src/eigenda_blobs.rs
+++ b/bin/host/src/eigenda_blobs.rs
@@ -26,11 +26,9 @@ impl OnlineEigenDABlobProvider {
     pub async fn fetch_eigenda_blob(
         &self,
         cert: &Bytes,
-    ) -> Result<alloy_rlp::Bytes, reqwest::Error> {
+    ) -> Result<reqwest::Response, reqwest::Error> {
         let url = format!("{}/{}/{}", self.base, GET_METHOD, cert);
 
-        let raw_response = self.inner.get(url).send().await?;
-
-        raw_response.bytes().await
+        self.inner.get(url).send().await
     }
 }


### PR DESCRIPTION
This PR works on a host bug that returns 500 error, and host forward it into derivation pipeline via get_blob

The fix is to check status code that is non successful.

Below is the previous result when querying an expired cert
`raw_response Response { url: "http://127.0.0.1:54694/get/0x010001f90195f9013cf8b5f87f80820001f858f8419ff9a3df33658fbcf6f639a2cb018c8a6bbf3cbbc9289a45ade03189be00aaf8a02e0d7590c214cd52573b48f996a777cf7dcbab3c7d131d0f02a4b18c8a95ef49ccc68202ff820290c4378201a7c6c28080c2808004a0e6700ad5127a28da78738790d3f94965414d25bdc6e2be1bbebc2d22e1cbf18bb09f3a77d0dd6b2b205c3edc677eb5b381f86fc60dea418427c07caa5df73635559880479283ff8730c812f25eb8b66f45c21b17820383b8805bad8f12eb8b25c6c174a221c0c3d489f06ef759a8d56647b1e6724666818f10f7c45a7e02907b34d46ba79df9071b43bd84fa01ca7cbd6e1b43b68973a2c92f0b10fd33aaead5cebcf32d55e3a52bf4298d9ee7d1bcd8de6618d0f1523b7cb384f09c24937fae8e1bf63c411dc66a072dd816c1edc303a8eeaeabd60b4abb02e2a0676fa65b2a7f9c050c181d0be2969a9b593c6ea2d9a23ddb1241e3ee822053b20ff1c2121ec7c682015682013ac4c381aa21ccc68201f78224b9c482020114c581ff82027dc20802c31c0c07c6c2010bc21c1080", status: 500, headers: {"content-type": "text/plain; charset=utf-8", "x-content-type-options": "nosniff", "date": "Wed, 21 May 2025 01:42:21 GMT", "content-length": "1019"} }
`