### PR TITLE
chore: justfile split build-natove

### DIFF
--- a/.github/workflows/rust_ci.yaml
+++ b/.github/workflows/rust_ci.yaml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        justfile-target: [build-native, build-client-for-asterisc]
+        justfile-target: [build-native-all, build-client-for-asterisc]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/justfile
+++ b/justfile
@@ -9,12 +9,17 @@ default:
 # Build the workspace for all available targets
 alias b := build-all
 [group('build')]
-build-all: build-native build-client-for-asterisc
+build-all: build-native-all build-client-for-asterisc
+
+# Build for the all native target
+[group('build')]
+build-native-all *args='':
+  cargo build --workspace $@
 
 # Build for the native target
 [group('build')]
 build-native *args='':
-  cargo build --workspace $@
+  cargo build hokulea-host-bin
 
 # Build `hokulea-client` for the `asterisc` target.
 [group('build')]


### PR DESCRIPTION
Currently, in order to run kurtosis

It will first run build-native, which build for all worksapces including those relates for sp1-cc and steel

This is not needed for our current CI. split build-native to 
- build-native: to native host
- build-native-all: for all workspace

This can avoid the out of disk issue.

<img width="936" alt="Screenshot 2025-06-07 at 11 40 13 PM" src="https://github.com/user-attachments/assets/7d777ba9-b22e-4341-b1d8-7e422d554282" />

