### PR TITLE
refactor canoe proof gen and replace error types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4065,9 +4065,7 @@ dependencies = [
 name = "hokulea-example-preloader"
 version = "0.1.0"
 dependencies = [
- "alloy-consensus 1.0.9",
  "alloy-evm 0.10.0",
- "alloy-rlp",
  "anyhow",
  "canoe-provider",
  "canoe-sp1-cc-host",
@@ -4145,12 +4143,18 @@ dependencies = [
 name = "hokulea-witgen"
 version = "0.1.0"
 dependencies = [
+ "alloy-consensus 1.0.9",
  "alloy-primitives 1.2.0",
+ "alloy-rlp",
+ "anyhow",
  "async-trait",
+ "canoe-provider",
  "eigenda-cert",
  "hokulea-compute-proof",
  "hokulea-eigenda",
  "hokulea-proof",
+ "kona-preimage",
+ "kona-proof",
  "rust-kzg-bn254-primitives",
 ]
 
@@ -4159,7 +4163,6 @@ name = "hokulea-zkvm-verification"
 version = "0.1.0"
 dependencies = [
  "hokulea-proof",
- "kona-client",
  "kona-preimage",
  "kona-proof",
 ]

--- a/crates/proof/src/canoe_verifier/sp1_cc.rs
+++ b/crates/proof/src/canoe_verifier/sp1_cc.rs
@@ -9,7 +9,7 @@ use tracing::{info, warn};
 // ToDo(bx) how to automtically update it from ELF directly as oppose to hard code it
 // To get vKey of ELF
 // cargo prove vkey --elf target/elf-compilation/riscv32im-succinct-zkvm-elf/release/canoe-sp1-cc-client
-pub const VKEYHEXSTRING: &str = "0015b0a5da54dfa9e02044ae5c4ccf2e5e0d464c1d22e56c70b97799473c22b0";
+pub const VKEYHEXSTRING: &str = "000c14f7db37c67a3385e24e60016e160634d73fb9b01f69073a46f259b5f302";
 
 #[derive(Clone)]
 pub struct CanoeSp1CCVerifier {}

--- a/crates/witgen/Cargo.toml
+++ b/crates/witgen/Cargo.toml
@@ -6,12 +6,18 @@ edition = "2021"
 
 [dependencies]
 alloy-primitives.workspace = true
+alloy-consensus.workspace = true
+alloy-rlp.workspace = true
 
+kona-proof.workspace = true
+kona-preimage.workspace = true
 hokulea-proof.workspace = true
 hokulea-compute-proof.workspace = true
 hokulea-eigenda.workspace = true
 eigenda-cert.workspace = true
+canoe-provider.workspace = true
 
 rust-kzg-bn254-primitives.workspace = true
 
 async-trait.workspace = true
+anyhow.workspace = true

--- a/crates/witgen/Cargo.toml
+++ b/crates/witgen/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
-alloy-rlp.workspace = true
+alloy-rlp = { workspace = true, features = ["std"] }
 
 kona-proof.workspace = true
 kona-preimage.workspace = true

--- a/crates/witgen/Cargo.toml
+++ b/crates/witgen/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
-alloy-rlp = { workspace = true, features = ["std"] }
+alloy-rlp = { workspace = true }
 
 kona-proof.workspace = true
 kona-preimage.workspace = true

--- a/crates/witgen/src/canoe_witness_provider.rs
+++ b/crates/witgen/src/canoe_witness_provider.rs
@@ -23,7 +23,8 @@ where
     let header_rlp = oracle
         .get(PreimageKey::new_keccak256(*boot_info.l1_head))
         .await?;
-    let l1_head_header = Header::decode(&mut header_rlp.as_slice())?;
+    let l1_head_header = Header::decode(&mut header_rlp.as_slice())
+        .map_err(|_| anyhow::Error::msg("cannot rlp decode header in canoe proof generation"))?;
     let l1_chain_id = boot_info.rollup_config.l1_chain_id;
 
     let mut wit = witness.clone();

--- a/crates/witgen/src/canoe_witness_provider.rs
+++ b/crates/witgen/src/canoe_witness_provider.rs
@@ -1,0 +1,55 @@
+use alloy_consensus::Header;
+use alloy_rlp::Decodable;
+use canoe_provider::{CanoeInput, CanoeProvider};
+use core::fmt::Debug;
+use hokulea_proof::eigenda_blob_witness::EigenDABlobWitnessData;
+use kona_preimage::{CommsClient, PreimageKey};
+use kona_proof::{BootInfo, FlushableCache};
+use std::sync::Arc;
+
+/// A helper function to create canoe proof by the provided canoe provider.
+/// The function relies on data stored in the oracle, for l1_head, l1_head_number
+/// and chain_id.
+pub async fn from_boot_info_to_canoe_proof<P, O>(
+    boot_info: &BootInfo,
+    witness: &EigenDABlobWitnessData,
+    oracle: Arc<O>,
+    canoe_provider: P,
+) -> anyhow::Result<Vec<P::Receipt>>
+where
+    P: CanoeProvider,
+    O: CommsClient + FlushableCache + Send + Sync + Debug,
+{
+    let header_rlp = oracle
+        .get(PreimageKey::new_keccak256(*boot_info.l1_head))
+        .await
+        .expect("get l1 header based on l1 head");
+    let l1_head_header = Header::decode(&mut header_rlp.as_slice()).expect("rlp decode l1 header");
+    let l1_chain_id = boot_info.rollup_config.l1_chain_id;
+
+    let mut wit = witness.clone();
+
+    // generate canoe proof
+    wit.validity.iter_mut().for_each(|(_, cert_validity)| {
+        cert_validity.l1_head_block_hash = boot_info.l1_head;
+    });
+
+    let mut canoe_proofs = vec![];
+
+    for (altda_commitment, cert_validity) in &mut wit.validity {
+        let canoe_input = CanoeInput {
+            altda_commitment: altda_commitment.clone(),
+            claimed_validity: cert_validity.claimed_validity,
+            l1_head_block_hash: boot_info.l1_head,
+            l1_head_block_number: l1_head_header.number,
+            l1_chain_id,
+        };
+
+        let canoe_proof = canoe_provider
+            .create_cert_validity_proof(canoe_input)
+            .await
+            .expect("must be able generate a canoe zk proof attesting eth state");
+        canoe_proofs.push(canoe_proof);
+    }
+    Ok(canoe_proofs)
+}

--- a/crates/witgen/src/canoe_witness_provider.rs
+++ b/crates/witgen/src/canoe_witness_provider.rs
@@ -8,7 +8,7 @@ use kona_proof::{BootInfo, FlushableCache};
 use std::sync::Arc;
 
 /// A helper function to create canoe proof by the provided canoe provider.
-/// The function relies on data stored in the oracle, for l1_head, l1_head_number
+/// The function relies on data stored in the oracle, for l1_head, l1_head_header.number
 /// and chain_id.
 pub async fn from_boot_info_to_canoe_proof<P, O>(
     boot_info: &BootInfo,
@@ -22,9 +22,8 @@ where
 {
     let header_rlp = oracle
         .get(PreimageKey::new_keccak256(*boot_info.l1_head))
-        .await
-        .expect("get l1 header based on l1 head");
-    let l1_head_header = Header::decode(&mut header_rlp.as_slice()).expect("rlp decode l1 header");
+        .await?;
+    let l1_head_header = Header::decode(&mut header_rlp.as_slice())?;
     let l1_chain_id = boot_info.rollup_config.l1_chain_id;
 
     let mut wit = witness.clone();
@@ -47,8 +46,7 @@ where
 
         let canoe_proof = canoe_provider
             .create_cert_validity_proof(canoe_input)
-            .await
-            .expect("must be able generate a canoe zk proof attesting eth state");
+            .await?;
         canoe_proofs.push(canoe_proof);
     }
     Ok(canoe_proofs)

--- a/crates/witgen/src/lib.rs
+++ b/crates/witgen/src/lib.rs
@@ -1,1 +1,3 @@
+pub mod canoe_witness_provider;
 pub mod witness_provider;
+pub use canoe_witness_provider::from_boot_info_to_canoe_proof;

--- a/crates/zkvm-verification/Cargo.toml
+++ b/crates/zkvm-verification/Cargo.toml
@@ -5,6 +5,5 @@ edition = "2021"
 
 [dependencies]
 hokulea-proof.workspace = true
-kona-client.workspace = true
 kona-preimage.workspace = true
 kona-proof.workspace = true

--- a/crates/zkvm-verification/src/lib.rs
+++ b/crates/zkvm-verification/src/lib.rs
@@ -2,9 +2,8 @@
 
 extern crate alloc;
 use core::fmt::Debug;
-use kona_client::single::FaultProofProgramError;
 use kona_preimage::CommsClient;
-use kona_proof::{BootInfo, FlushableCache};
+use kona_proof::{errors::OracleProviderError, BootInfo, FlushableCache};
 
 use hokulea_proof::{
     canoe_verifier::CanoeVerifier, eigenda_blob_witness::EigenDABlobWitnessData,
@@ -23,7 +22,7 @@ pub async fn eigenda_witness_to_preloaded_provider<O>(
     oracle: Arc<O>,
     canoe_verifier: impl CanoeVerifier,
     mut witness: EigenDABlobWitnessData,
-) -> Result<PreloadedEigenDABlobProvider, FaultProofProgramError>
+) -> Result<PreloadedEigenDABlobProvider, OracleProviderError>
 where
     O: CommsClient + FlushableCache + Send + Sync + Debug,
 {

--- a/example/preloader/Cargo.toml
+++ b/example/preloader/Cargo.toml
@@ -23,9 +23,6 @@ kona-client.workspace = true
 kona-preimage.workspace = true
 kona-proof.workspace = true
 
-alloy-consensus.workspace = true
-alloy-rlp.workspace = true
-
 # Execution
 alloy-evm.workspace = true
 op-revm.workspace = true


### PR DESCRIPTION
This PR refactor canoe_proof_gen from the preloader example into a helper function.

It is asked from op-succinct to reduce the size of code, their side has to copy in order to generate canoe proof. Although it is not a blocker at the moment.

This PR also changes the error type, FaultProofProgramError, in various places. The change makes the error type more accurate. Also, example should have used anyhow


Fix #142
Fix DAINT-572