### PR TITLE
fix: update canoe-sp1-cc-client elf in github

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,5 @@ state.bin.gz
 .run.*.env
 canoe/steel/methods/contracts/ImageID.sol
 canoe/steel/methods/contracts/ELF.sol
-canoe/sp1-cc/elf/canoe-sp1-cc-client
 .DS_store
 .idea


### PR DESCRIPTION
It turned out it's required that canoe-sp1-cc-client elf is included in the repo. 

Op-succinct requires access to ELF to initialize the prover. See

https://github.com/celo-org/op-succinct/blob/9ac7ea3028577a191a4cec850dae4c7bf01c1d9f/utils/eigenda/host/src/witness_generator.rs#L57