### PR TITLE
fix: implement encoded payload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4447,7 +4447,6 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives 1.2.0",
  "async-trait",
- "bytes",
  "eigenda-cert",
  "kona-derive",
  "kona-protocol",
@@ -9069,8 +9068,7 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 [[package]]
 name = "rust-kzg-bn254-primitives"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a986f25bc8871261f26f4ec74ef9215d0920ec140f2ef2dfd441b33fd121738b"
+source = "git+https://github.com/Layr-Labs/rust-kzg-bn254.git?rev=4d1d6a84910a3fc1e5e8927f694e4fc10ac5dd9d#4d1d6a84910a3fc1e5e8927f694e4fc10ac5dd9d"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -9088,8 +9086,7 @@ dependencies = [
 [[package]]
 name = "rust-kzg-bn254-prover"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed1af11c66ca1e505ef959e398e86c39d9b2b20d0aa9a45a62e053a8a9044209"
+source = "git+https://github.com/Layr-Labs/rust-kzg-bn254.git?rev=4d1d6a84910a3fc1e5e8927f694e4fc10ac5dd9d#4d1d6a84910a3fc1e5e8927f694e4fc10ac5dd9d"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -9106,8 +9103,7 @@ dependencies = [
 [[package]]
 name = "rust-kzg-bn254-verifier"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b1a1996f1d61c05d732aac54b1ecfc11abbf73a47b3e4ca72f92ecdd75214f"
+source = "git+https://github.com/Layr-Labs/rust-kzg-bn254.git?rev=4d1d6a84910a3fc1e5e8927f694e4fc10ac5dd9d#4d1d6a84910a3fc1e5e8927f694e4fc10ac5dd9d"
 dependencies = [
  "ark-bn254",
  "ark-ec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,9 +111,9 @@ anyhow = { version = "1.0.98", default-features = false }
 lazy_static = { version = "1.5.0", default-features = false }
 
 
-rust-kzg-bn254-primitives = { version = "0.1.2", default-features = false }
-rust-kzg-bn254-verifier = { version = "0.1.2", default-features = false }
-rust-kzg-bn254-prover = { version = "0.1.1", default-features = false }
+rust-kzg-bn254-primitives = { version = "0.1.2", git = "https://github.com/Layr-Labs/rust-kzg-bn254.git", rev = "4d1d6a84910a3fc1e5e8927f694e4fc10ac5dd9d", default-features = false }
+rust-kzg-bn254-verifier = { version = "0.1.2", git = "https://github.com/Layr-Labs/rust-kzg-bn254.git", rev = "4d1d6a84910a3fc1e5e8927f694e4fc10ac5dd9d", default-features = false }
+rust-kzg-bn254-prover = { version = "0.1.1", git = "https://github.com/Layr-Labs/rust-kzg-bn254.git", rev = "4d1d6a84910a3fc1e5e8927f694e4fc10ac5dd9d", default-features = false }
 
 ark-bn254 = { version = "0.5.0", default-features = false }
 ark-ff = { version = "0.5.0", default-features = false }

--- a/bin/host/src/handler.rs
+++ b/bin/host/src/handler.rs
@@ -251,7 +251,7 @@ async fn store_blob_data(
     // Verify blob data is properly formatted
     assert!(
         encoded_payload.encoded_payload.len() % 32 == 0
-            && encoded_payload.encoded_payload.len() != 0
+            && !encoded_payload.encoded_payload.is_empty()
     );
 
     // Preliminary defense check against malicious eigenda proxy host

--- a/bin/host/src/handler.rs
+++ b/bin/host/src/handler.rs
@@ -7,8 +7,9 @@ use async_trait::async_trait;
 use eigenda_cert::AltDACommitment;
 use hokulea_eigenda::{EncodedPayload, HokuleaPreimageError};
 use hokulea_eigenda::{
-    BYTES_PER_FIELD_ELEMENT, PAYLOAD_ENCODING_VERSION_0, RESERVED_EIGENDA_API_BYTE_FOR_RECENCY,
-    RESERVED_EIGENDA_API_BYTE_FOR_VALIDITY, RESERVED_EIGENDA_API_BYTE_INDEX,
+    BYTES_PER_FIELD_ELEMENT, ENCODED_PAYLOAD_HEADER_LEN_BYTES, PAYLOAD_ENCODING_VERSION_0,
+    RESERVED_EIGENDA_API_BYTE_FOR_RECENCY, RESERVED_EIGENDA_API_BYTE_FOR_VALIDITY,
+    RESERVED_EIGENDA_API_BYTE_INDEX,
 };
 use hokulea_proof::hint::ExtendedHintType;
 use kona_host::SharedKeyValueStore;
@@ -247,11 +248,30 @@ async fn store_blob_data(
     // Prepare blob data
     let blob_length_fe = altda_commitment.get_num_field_element();
     let encoded_payload = EncodedPayload::encode(rollup_data.as_ref(), PAYLOAD_ENCODING_VERSION_0);
-
     // Verify blob data is properly formatted
     assert!(encoded_payload.encoded_payload.len() % 32 == 0);
-    let fetch_num_element = (encoded_payload.encoded_payload.len() / BYTES_PER_FIELD_ELEMENT) as u64;
 
+    // Preliminary defense check against malicious eigenda proxy host
+    // Validate field elements (keeping existing field element validation for compatibility)
+    let encoded_payload_body = &encoded_payload.encoded_payload[ENCODED_PAYLOAD_HEADER_LEN_BYTES..];
+    // verify there is an empty byte for every 31 bytes. This is a harder constraint than field element range check.
+    for chunk in encoded_payload_body.chunks_exact(BYTES_PER_FIELD_ELEMENT) {
+        // very conservative check on Field element range. It allows us to detect
+        // misbehaving at the host side when providing the field element. So we can stop early.
+        // the field element of on bn254 curve is some number less than 2^254
+        // that means both 255 and 254 th bits must be 0. out of conservation, we require the
+        // 253 bit to be 0. It aligns with our encoding scheme below that the first 8bits
+        // should be 0.
+        // Field elements are interpreted as big endian
+        if chunk[0] & 0b1110_0000 != 0 {
+            return Err(anyhow!("invalid field element encoding"));
+        }
+        // we don't have the check that the first 8 bits are zero, because it is a more restrictive check, that might
+        // affect future payload encoding scheme
+    }
+
+    let fetch_num_element =
+        (encoded_payload.encoded_payload.len() / BYTES_PER_FIELD_ELEMENT) as u64;
     // Store each field element
     let mut field_element_key = altda_commitment.digest_template();
     for i in 0..blob_length_fe as u64 {

--- a/bin/host/src/handler.rs
+++ b/bin/host/src/handler.rs
@@ -249,7 +249,10 @@ async fn store_blob_data(
     let blob_length_fe = altda_commitment.get_num_field_element();
     let encoded_payload = EncodedPayload::encode(rollup_data.as_ref(), PAYLOAD_ENCODING_VERSION_0);
     // Verify blob data is properly formatted
-    assert!(encoded_payload.encoded_payload.len() % 32 == 0);
+    assert!(
+        encoded_payload.encoded_payload.len() % 32 == 0
+            && encoded_payload.encoded_payload.len() != 0
+    );
 
     // Preliminary defense check against malicious eigenda proxy host
     // Validate field elements (keeping existing field element validation for compatibility)
@@ -263,11 +266,11 @@ async fn store_blob_data(
         // 253 bit to be 0. It aligns with our encoding scheme below that the first 8bits
         // should be 0.
         // Field elements are interpreted as big endian
+        // We don't have the check that the first 8 bits are zero, because it is a more restrictive check, that might
+        // affect future payload encoding scheme
         if chunk[0] & 0b1110_0000 != 0 {
             return Err(anyhow!("invalid field element encoding"));
         }
-        // we don't have the check that the first 8 bits are zero, because it is a more restrictive check, that might
-        // affect future payload encoding scheme
     }
 
     let fetch_num_element =

--- a/crates/compute-proof/src/kzg_proof.rs
+++ b/crates/compute-proof/src/kzg_proof.rs
@@ -21,7 +21,7 @@ pub fn compute_kzg_proof(blob: &[u8]) -> Result<Bytes, KzgError> {
         .unwrap_or_else(|err| panic!("Failed to load SRS file {}: {}", srs_file_path, err));
     let mut kzg = KZG::new();
 
-    let input = Blob::new(blob);
+    let input = Blob::new(blob).expect("should be able to construct a blob");
     let input_poly = input.to_polynomial_eval_form();
 
     kzg.calculate_and_store_roots_of_unity(blob.len() as u64)

--- a/crates/eigenda/Cargo.toml
+++ b/crates/eigenda/Cargo.toml
@@ -10,7 +10,6 @@ eigenda-cert.workspace = true
 alloy-primitives.workspace = true
 tracing.workspace = true
 async-trait.workspace = true
-bytes.workspace = true
 rust-kzg-bn254-primitives.workspace = true
 kona-protocol.workspace = true
 thiserror.workspace = true

--- a/crates/eigenda/src/constant.rs
+++ b/crates/eigenda/src/constant.rs
@@ -5,3 +5,5 @@ pub const PAYLOAD_ENCODING_VERSION_0: u8 = 0x0;
 pub const STALE_GAP: u64 = 100;
 /// Number of fields for field element on bn254
 pub const BYTES_PER_FIELD_ELEMENT: usize = 32;
+/// Encoded payload header length in bytes (first field element)
+pub const ENCODED_PAYLOAD_HEADER_LEN_BYTES: usize = 32;

--- a/crates/eigenda/src/eigenda.rs
+++ b/crates/eigenda/src/eigenda.rs
@@ -4,7 +4,7 @@ use crate::traits::EigenDABlobProvider;
 use crate::{eigenda_blobs::EigenDABlobSource, HokuleaErrorKind};
 use kona_derive::errors::PipelineErrorKind;
 
-use crate::eigenda_data::EigenDABlobData;
+use crate::eigenda_data::EncodedPayload;
 use alloc::vec::Vec;
 use alloc::{boxed::Box, fmt::Debug};
 use alloy_primitives::{Address, Bytes};
@@ -20,7 +20,7 @@ use tracing::warn;
 
 #[derive(Debug, Clone)]
 pub enum EigenDAOrCalldata {
-    EigenDA(EigenDABlobData),
+    EigenDA(EncodedPayload),
     Calldata(Bytes),
 }
 

--- a/crates/eigenda/src/eigenda_blobs.rs
+++ b/crates/eigenda/src/eigenda_blobs.rs
@@ -1,6 +1,6 @@
 //! Blob Data Source
 
-use crate::eigenda_data::EigenDABlobData;
+use crate::eigenda_data::EncodedPayload;
 use crate::traits::EigenDABlobProvider;
 use crate::HokuleaPreimageError;
 
@@ -33,7 +33,7 @@ where
         &mut self,
         calldata: &Bytes,
         l1_inclusion_bn: u64,
-    ) -> Result<EigenDABlobData, HokuleaErrorKind> {
+    ) -> Result<EncodedPayload, HokuleaErrorKind> {
         let eigenda_commitment = self.parse(calldata)?;
 
         info!(target: "eigenda_blob_source", "parsed an altda commitment of version {}", eigenda_commitment.cert_version_str());
@@ -69,13 +69,13 @@ where
         // get blob via preimage oracle
         match self.eigenda_fetcher.get_blob(&eigenda_commitment).await {
             Ok(data) => {
-                let new_blob: Vec<u8> = data.into();
+                let encoded_payload_bytes: Vec<u8> = data.into();
 
-                let eigenda_blob = EigenDABlobData {
-                    blob: new_blob.into(),
+                let encoded_payload = EncodedPayload {
+                    encoded_payload: encoded_payload_bytes.into(),
                 };
 
-                Ok(eigenda_blob)
+                Ok(encoded_payload)
             }
             Err(e) => Err(e.into()),
         }

--- a/crates/eigenda/src/eigenda_data.rs
+++ b/crates/eigenda/src/eigenda_data.rs
@@ -148,7 +148,7 @@ impl EncodedPayload {
     /// The length of (header + payload) by the encode function is always multiple of 32
     /// The eigenda proxy does not take such constraint.
     ///
-    /// (ToDo) with new proxy release, it can return the encoded payload, the encode function can
+    /// (ToDo) with proxy release 2.2.1, it can return the encoded payload, the encode function can
     /// be moved into test, and no longer used anywhere else
     pub fn encode(rollup_data: &[u8], payload_encoding_version: u8) -> Self {
         let rollup_data_size = rollup_data.len() as u32;

--- a/crates/eigenda/src/eigenda_data.rs
+++ b/crates/eigenda/src/eigenda_data.rs
@@ -1,82 +1,138 @@
-use crate::PAYLOAD_ENCODING_VERSION_0;
 use crate::{
-    errors::{BlobDecodingError, HokuleaStatelessError},
+    errors::{EncodedPayloadDecodingError, HokuleaStatelessError},
     BYTES_PER_FIELD_ELEMENT,
 };
+use crate::{ENCODED_PAYLOAD_HEADER_LEN_BYTES, PAYLOAD_ENCODING_VERSION_0};
 use alloc::vec;
 use alloy_primitives::Bytes;
-use bytes::buf::Buf;
 use rust_kzg_bn254_primitives::helpers;
+
+/// Represents raw payload bytes, alias
+pub type Payload = Bytes;
 
 #[derive(Default, Clone, Debug)]
 /// Represents the data structure for EigenDA Blob
 /// intended for deriving rollup channel frame from eigenda blob
 pub struct EncodedPayload {
-    /// The calldata
+    /// Bytes over Vec because Bytes clone is a shallow copy
     pub encoded_payload: Bytes,
 }
 
 impl EncodedPayload {
-    /// Decodes the blob into raw byte data. Reverse of the encode function below
-    /// Returns a [BlobDecodingError] if the blob is invalid.
-    pub fn decode(&self) -> Result<Bytes, HokuleaStatelessError> {
-        let encoded_payload = &self.encoded_payload;
-        if encoded_payload.len() < 32 {
-            return Err(BlobDecodingError::InvalidBlobSizeInBytes(encoded_payload.len() as u64).into());
+    /// Constructs an EncodedPayload from bytes array.
+    /// Does not validate the bytes, to mimic the Blob.ToEncodedPayloadUnchecked process.
+    /// The length, header, and body invariants are checked when calling decode.
+    pub fn deserialize(bytes: Bytes) -> Self {
+        Self {
+            encoded_payload: bytes,
         }
+    }
 
-        // blob must have multiple of 32 bytes
-        if encoded_payload.len() % BYTES_PER_FIELD_ELEMENT != 0 {
-            return Err(BlobDecodingError::InvalidBlobSizeInBytes(encoded_payload.len() as u64).into());
+    /// Returns the raw bytes of the encoded payload.
+    pub fn serialize(&self) -> &Bytes {
+        &self.encoded_payload
+    }
+
+    /// Returns the number of symbols in the encoded payload
+    pub fn len_symbols(&self) -> u32 {
+        (self.encoded_payload.len() / BYTES_PER_FIELD_ELEMENT) as u32
+    }
+
+    /// Checks whether the encoded payload satisfies its length invariant.
+    /// EncodedPayloads must contain a power of 2 number of Field Elements, each of length 32.
+    /// This means the only valid encoded payloads have byte lengths of 32, 64, 128, 256, etc.
+    ///
+    /// Note that this function only checks the length invariant, meaning that it doesn't check that
+    /// the 32 byte chunks are valid bn254 elements.
+    fn check_len_invariant(&self) -> Result<(), HokuleaStatelessError> {
+        // this check is redundant since 0 is not a valid power of 32, but we keep it for clarity.
+        if self.encoded_payload.len() < ENCODED_PAYLOAD_HEADER_LEN_BYTES {
+            return Err(EncodedPayloadDecodingError::PayloadTooShortForHeader {
+                expected: ENCODED_PAYLOAD_HEADER_LEN_BYTES,
+                actual: self.encoded_payload.len(),
+            }
+            .into());
         }
-
-        // for every user payload, there is a encoding version, currently only one version is
-        // supported, i.e. padding 0 for every 31 bytes
-        let blob_encoding_version = encoded_payload[1];
-        if blob_encoding_version != PAYLOAD_ENCODING_VERSION_0 {
+        // Check encoded payload has a power of two number of field elements
+        let num_field_elements = self.encoded_payload.len() / BYTES_PER_FIELD_ELEMENT;
+        if !is_power_of_two(num_field_elements) {
             return Err(
-                BlobDecodingError::InvalidBlobEncodingVersion(blob_encoding_version).into(),
+                EncodedPayloadDecodingError::InvalidPowerOfTwoLength(num_field_elements).into(),
             );
         }
+        Ok(())
+    }
 
-        // see https://github.com/Layr-Labs/eigenda/blob/f8b0d31d65b29e60172507074922668f4ca89420/api/clients/codecs/default_blob_codec.go#L44
-        let content_size = encoded_payload.slice(2..6).get_u32();
-        debug!(target: "eigenda-datasource", "content_size {:?}", content_size);
-
-        // the first 32 Bytes are reserved as the header field element
-        let codec_data = encoded_payload.slice(32..);
-
-        // verify there is an empty byte for every 31 bytes
-        // this is a harder constraint than field element range check.
-        for chunk in codec_data.chunks_exact(BYTES_PER_FIELD_ELEMENT) {
-            // very conservative check on Field element range. It allows us to detect
-            // mishaving at the host side when providing the field element. So we can stop early.
-            // the field element of on bn254 curve is some number less than 2^254
-            // that means both 255 and 254 th bits must be 0. iut of conservation, we require the
-            // 253 bit to be 0. It aligns with our encoding scheme below that the first 8bits
-            // should be 0.
-            // Field elements are interpreted as big endian
-            if chunk[0] & 0b1110_0000 != 0 {
-                return Err(HokuleaStatelessError::FieldElementRangeError);
+    /// Validates the header (first field element = 32 bytes) of the encoded payload,
+    /// and returns the claimed length of the payload if the header is valid.
+    fn decode_header(&self) -> Result<u32, HokuleaStatelessError> {
+        if self.encoded_payload.len() < ENCODED_PAYLOAD_HEADER_LEN_BYTES {
+            return Err(EncodedPayloadDecodingError::PayloadTooShortForHeader {
+                expected: ENCODED_PAYLOAD_HEADER_LEN_BYTES,
+                actual: self.encoded_payload.len(),
             }
-
-            // field elements are interpreted as big endian. It can happen either because
-            // the host is misbehaving, or the op-batcher is not following the eigenda
-            // encoding standard
-            if chunk[0] != 0x0 {
-                return Err(BlobDecodingError::InvalidBlobEncoding.into());
+            .into());
+        }
+        if self.encoded_payload[0] != 0x00 {
+            return Err(EncodedPayloadDecodingError::InvalidHeaderFirstByte(
+                self.encoded_payload[0],
+            )
+            .into());
+        }
+        let payload_length = match self.encoded_payload[1] {
+            version if version == PAYLOAD_ENCODING_VERSION_0 => u32::from_be_bytes([
+                self.encoded_payload[2],
+                self.encoded_payload[3],
+                self.encoded_payload[4],
+                self.encoded_payload[5],
+            ]),
+            version => {
+                return Err(EncodedPayloadDecodingError::UnknownEncodingVersion(version).into());
             }
+        };
+        Ok(payload_length)
+    }
+
+    /// Decodes the payload from the encoded payload bytes.
+    /// Removes internal padding and extracts the payload data based on the claimed length.
+    fn decode_payload(&self, payload_len: u32) -> Result<Payload, HokuleaStatelessError> {
+        let body = self
+            .encoded_payload
+            .slice(ENCODED_PAYLOAD_HEADER_LEN_BYTES..);
+
+        // Decode the body by removing internal 0 byte padding (0x00 initial byte for every 32 byte chunk)
+        // The decodedBody should contain the payload bytes + potentially some external padding bytes.
+        let decoded_body = helpers::remove_internal_padding(body.as_ref())
+            .map_err(|_| EncodedPayloadDecodingError::InvalidBlobSizeInBytes(body.len() as u64))?;
+        let decoded_body: Bytes = decoded_body.into();
+
+        // data length is checked when constructing an encoded payload. If this error is encountered, that means there
+        // must be a flaw in the logic at construction time (or someone was bad and didn't use the proper construction methods)
+        if (decoded_body.len() as u32) < payload_len {
+            return Err(EncodedPayloadDecodingError::UnpaddedDataTooShort {
+                actual: decoded_body.len(),
+                claimed: payload_len,
+            }
+            .into());
         }
 
-        // rust kzg bn254 impl already
-        let blob_content =
-            helpers::remove_empty_byte_from_padded_bytes_unchecked(codec_data.as_ref());
-        let blob_content: Bytes = blob_content.into();
+        Ok(decoded_body.slice(0..payload_len as usize))
+    }
 
-        if blob_content.len() < content_size as usize {
-            return Err(BlobDecodingError::InvalidContentSize.into());
-        }
-        Ok(blob_content.slice(..content_size as usize))
+    /// Decodes the blob into raw byte data. Reverse of the encode function below
+    /// Returns a [EncodedPayloadDecodingError] if the blob is invalid.
+    ///
+    /// Applies the inverse of PayloadEncodingVersion0 to an EncodedPayload, and returns the decoded payload.
+    pub fn decode(&self) -> Result<Payload, HokuleaStatelessError> {
+        // Check length invariant
+        self.check_len_invariant()?;
+
+        // Decode header to get claimed payload length
+        let payload_len_in_header = self.decode_header()?;
+        debug!(target: "eigenda-datasource", "rollup payload length in bytes {:?}", payload_len_in_header);
+
+        // Decode payload using the helper method
+        self.decode_payload(payload_len_in_header)
     }
 
     /// The encode function accepts an input of opaque rollup data array into an EigenDABlobData.
@@ -90,11 +146,14 @@ impl EncodedPayload {
     ///
     /// The length of (header + payload) by the encode function is always multiple of 32
     /// The eigenda proxy does not take such constraint.
+    ///
+    /// (ToDo) with new proxy release, it can return the encoded payload, the encode function can
+    /// be moved into test, and no longer used anywhere else
     pub fn encode(rollup_data: &[u8], payload_encoding_version: u8) -> Self {
         let rollup_data_size = rollup_data.len() as u32;
 
         // encode to become raw blob
-        let codec_rollup_data = helpers::convert_by_padding_empty_byte(rollup_data);
+        let codec_rollup_data = helpers::pad_payload(rollup_data);
 
         let blob_payload_size = codec_rollup_data.len();
 
@@ -117,6 +176,11 @@ impl EncodedPayload {
             encoded_payload: Bytes::from(raw_blob),
         }
     }
+}
+
+/// Utility function to check if a number is a power of two
+fn is_power_of_two(n: usize) -> bool {
+    n != 0 && (n & (n - 1)) == 0
 }
 
 #[cfg(test)]
@@ -159,7 +223,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err(),
-            BlobDecodingError::InvalidBlobSizeInBytes(33).into()
+            EncodedPayloadDecodingError::InvalidBlobSizeInBytes(33).into()
         );
     }
 }

--- a/crates/eigenda/src/eigenda_data.rs
+++ b/crates/eigenda/src/eigenda_data.rs
@@ -102,8 +102,9 @@ impl EncodedPayload {
 
         // Decode the body by removing internal 0 byte padding (0x00 initial byte for every 32 byte chunk)
         // The decodedBody should contain the payload bytes + potentially some external padding bytes.
-        let decoded_body = helpers::remove_internal_padding(body.as_ref())
-            .map_err(|_| EncodedPayloadDecodingError::InvalidBlobSizeInBytes(body.len() as u64))?;
+        let decoded_body = helpers::remove_internal_padding(body.as_ref()).map_err(|_| {
+            EncodedPayloadDecodingError::InvalidLengthInEncodedPayloadBody(body.len() as u64)
+        })?;
         let decoded_body: Bytes = decoded_body.into();
 
         // data length is checked when constructing an encoded payload. If this error is encountered, that means there
@@ -221,9 +222,10 @@ mod tests {
         encoded_payload.encoded_payload.truncate(33);
         let result = encoded_payload.decode();
         assert!(result.is_err());
+        // after truncation, 33 - 32(header length) = 1
         assert_eq!(
             result.unwrap_err(),
-            EncodedPayloadDecodingError::InvalidBlobSizeInBytes(33).into()
+            EncodedPayloadDecodingError::InvalidLengthInEncodedPayloadBody(1).into()
         );
     }
 }

--- a/crates/eigenda/src/errors.rs
+++ b/crates/eigenda/src/errors.rs
@@ -34,7 +34,7 @@ pub enum HokuleaStatelessError {
     FieldElementRangeError,
     /// blob decoding error, inbox sender has violated the encoding rule
     #[error("cannot decode a blob")]
-    BlobDecodeError(#[from] BlobDecodingError),
+    BlobDecodeError(#[from] EncodedPayloadDecodingError),
 }
 
 /// define conversion error
@@ -55,19 +55,35 @@ impl From<HokuleaStatelessError> for HokuleaErrorKind {
 
 /// List of error can happen during blob decoding
 #[derive(Debug, thiserror::Error, PartialEq)]
-pub enum BlobDecodingError {
+pub enum EncodedPayloadDecodingError {
     /// the input blob has wrong size
     #[error("invalid blob length {0}")]
     InvalidBlobSizeInBytes(u64),
-    /// the input blob has wrong encoding version
-    #[error("invalid blob encoding version {0}")]
-    InvalidBlobEncodingVersion(u8),
-    /// the input blob violates the encoding semantics
-    #[error("invalid blob encoding")]
-    InvalidBlobEncoding,
-    /// the input blob has wrong size
-    #[error("invalid content size")]
-    InvalidContentSize,
+    /// encoded payload must contain a power of 2 number of field elements
+    #[error("encoded payload must be a power of 2 field elements (32 bytes chunks), but got {0} field elements")]
+    InvalidPowerOfTwoLength(usize),
+    /// encoded payload header validation error
+    #[error("encoded payload header first byte must be 0x00, but got {0:#04x}")]
+    InvalidHeaderFirstByte(u8),
+    /// encoded payload too short for header
+    #[error("encoded payload must be at least {expected} bytes long to contain a header, but got {actual} bytes")]
+    PayloadTooShortForHeader {
+        /// Expected minimum length
+        expected: usize,
+        /// Actual payload length
+        actual: usize,
+    },
+    /// unknown encoded payload header version
+    #[error("unknown encoded payload header version: {0}")]
+    UnknownEncodingVersion(u8),
+    /// length of unpadded data is less than claimed in header
+    #[error("length of unpadded data {actual} is less than length claimed in encoded payload header {claimed}")]
+    UnpaddedDataTooShort {
+        /// Actual unpadded data length
+        actual: usize,
+        /// Claimed length from header
+        claimed: u32,
+    },
 }
 
 /// A list of Hokulea error derived from data from preimage oracle

--- a/crates/eigenda/src/errors.rs
+++ b/crates/eigenda/src/errors.rs
@@ -57,8 +57,8 @@ impl From<HokuleaStatelessError> for HokuleaErrorKind {
 #[derive(Debug, thiserror::Error, PartialEq)]
 pub enum EncodedPayloadDecodingError {
     /// the input blob has wrong size
-    #[error("invalid blob length {0}")]
-    InvalidBlobSizeInBytes(u64),
+    #[error("invalid number of bytes in the encoded payload body {0}")]
+    InvalidLengthInEncodedPayloadBody(u64),
     /// encoded payload must contain a power of 2 number of field elements
     #[error("encoded payload must be a power of 2 field elements (32 bytes chunks), but got {0} field elements")]
     InvalidPowerOfTwoLength(usize),

--- a/crates/eigenda/src/lib.rs
+++ b/crates/eigenda/src/lib.rs
@@ -28,7 +28,7 @@ mod eigenda_blobs;
 pub use eigenda_blobs::EigenDABlobSource;
 
 mod eigenda_data;
-pub use eigenda_data::EigenDABlobData;
+pub use eigenda_data::EncodedPayload;
 
 mod errors;
 pub use errors::{

--- a/crates/eigenda/src/lib.rs
+++ b/crates/eigenda/src/lib.rs
@@ -28,14 +28,15 @@ mod eigenda_blobs;
 pub use eigenda_blobs::EigenDABlobSource;
 
 mod eigenda_data;
-pub use eigenda_data::EncodedPayload;
+pub use eigenda_data::{EncodedPayload, Payload};
 
 mod errors;
 pub use errors::{
-    BlobDecodingError, HokuleaErrorKind, HokuleaPreimageError, HokuleaStatelessError,
+    EncodedPayloadDecodingError, HokuleaErrorKind, HokuleaPreimageError, HokuleaStatelessError,
 };
 
 mod constant;
 pub use constant::BYTES_PER_FIELD_ELEMENT;
+pub use constant::ENCODED_PAYLOAD_HEADER_LEN_BYTES;
 pub use constant::PAYLOAD_ENCODING_VERSION_0;
 pub use constant::STALE_GAP;

--- a/crates/proof/src/preloaded_eigenda_provider.rs
+++ b/crates/proof/src/preloaded_eigenda_provider.rs
@@ -80,13 +80,14 @@ impl PreloadedEigenDABlobProvider {
         let mut commitments = vec![];
         //for i in 0..value.eigenda_certs.len() {
         for (cert, eigenda_blobs, kzg_proof) in value.blob {
+            let blob = Blob::new(&eigenda_blobs).expect("should be able to construct a blob");
             // if valid, check blob kzg integrity
-            blobs.push(Blob::new(&eigenda_blobs));
+            blobs.push(blob.clone());
             proofs.push(kzg_proof);
             commitments.push(cert.get_kzg_commitment());
 
             // populate entries ahead of time, if something is invalid, batch_verify will abort
-            blob_entries.push((cert.clone(), Blob::new(&eigenda_blobs)));
+            blob_entries.push((cert.clone(), blob));
         }
         // check if cert is not valie, the blob must be empty, assert that commitments in the cert and blobs are consistent
         assert!(batch_verify(blobs, commitments, proofs));

--- a/kurtosis_params.yaml
+++ b/kurtosis_params.yaml
@@ -49,8 +49,6 @@ optimism_package:
           - --target-num-frames=5
           - --max-l1-tx-size-bytes=1000
           - --batch-type=1
-          - --throttle-threshold=500_000
-          - --throttle-block-size=1000
       proposer_params:
         game_type: 1
         proposal_interval: 10m
@@ -65,7 +63,7 @@ optimism_package:
           - --memstore.enabled
           - --memstore.expiration=180m
           - --eigenda.v2.network=holesky_testnet # memstore disregard the network, but it simplifies the configuration 
-        image: ghcr.io/layr-labs/eigenda-proxy:latest
+        image: ghcr.io/layr-labs/eigenda-proxy:2.2.1
       network_params:
         fjord_time_offset: 0
         granite_time_offset: 0


### PR DESCRIPTION
Key Changes:
  - Renamed data struct: Changed from EigenDABlobData to EncodedPayload
  - Core implementation: translate proxy encoded payload impl to rust mainly by claude
  - Integration updates: Use a newer version of the rust kzg library

Kurtosis devnet parameter update 0d715d81dc12512fef9d23ac8b981ff5d4aa3c40:
- update proxy tag
- Changes in op-batcher parameter forces us to remove throttle parameter. See op change at [PR](https://github.com/ethereum-optimism/optimism/pull/17032). The stable kurtosis release uses the develop tag
<img width="1632" height="221" alt="Screenshot 2025-08-21 at 4 42 10 PM" src="https://github.com/user-attachments/assets/fe684677-c997-4837-aaa7-c5f9c35207d8" />

We could have used a tag of op-batcher, but downside is that we could use a significantly old software in the future. So not tagging for now

 
Key callout
 - I was attempting to work on renaming in the beginning, but its scope would be very large. Renaming will appear in another PR
 - Before renaming, I will have a new PR to use the newer release of proxy that fetch the encoded payload