### PR TITLE
Fix: skip cert verification if there is no cert validity check

### DIFF
--- a/crates/proof/src/preloaded_eigenda_provider.rs
+++ b/crates/proof/src/preloaded_eigenda_provider.rs
@@ -64,7 +64,7 @@ impl PreloadedEigenDABlobProvider {
         let mut validity_entries = vec![];
 
         // if the number of da cert is non-zero, verify the single canoe proof, regardless if the
-        // da cert is valid or not. Otherwise, skip the verification  
+        // da cert is valid or not. Otherwise, skip the verification
         if !value.validity.is_empty() {
             // check cert validity altogether in one verification
             canoe_verifier


### PR DESCRIPTION
This PR handles the case when there is no any DA certs requiring the validity preimage query.

Previously, it will verify the ZK proof when there is nothing to verify or prove against.

Now, it will skip the canoe verification within ZKVM entirely if there is no cert to verify against.