### PR TITLE
test: add mock object and test for eigenda preimage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4461,6 +4461,7 @@ dependencies = [
  "rust-kzg-bn254-primitives",
  "serde",
  "thiserror 2.0.12",
+ "tokio",
  "tracing",
 ]
 

--- a/crates/eigenda/Cargo.toml
+++ b/crates/eigenda/Cargo.toml
@@ -15,6 +15,9 @@ kona-protocol.workspace = true
 thiserror.workspace = true
 serde = { workspace = true, features = ["derive"] }
 
+[dev-dependencies]
+tokio = { workspace = true, features = ["full"] }
+
 [features]
 serde = [
   "kona-protocol/serde",

--- a/crates/eigenda/src/eigenda_preimage.rs
+++ b/crates/eigenda/src/eigenda_preimage.rs
@@ -88,3 +88,194 @@ where
         Ok(altda_commitment)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utils::{self, TestEigenDAPreimageSource, TestHokuleaProviderError};
+
+    use super::*;
+    use alloc::string::ToString;
+    use alloc::vec;
+    use alloy_primitives::hex;
+    use eigenda_cert::AltDACommitmentParseError;
+
+    const CALLDATA_HEX: &str = "0x01010001f9035ef901cdf901c8f9018080820001f90158f842a013cb9a6e004f28a193672a95b2ee4a2addc14bfe705eb3c1695f34dccfdf4d7fa01de675df78f68e6f40643f148b7dcf7b30e7bbb5ec5ed66efcf82e02a148b45ef888f842a00ca1a4b18243aed65a6887cb3da7ab7a9b8138261ad5fa7a7ef61fcf45ad0f77a012969add06ec97e0b24ef9f69633114966952c02150f8bb28a55a5fac60c7644f842a00c137feb7cf2cf625b826eebd5a1ffd400446e03336c6ff07061b7a9adc32376a00cd9277cc3e8c2a6c896c4e7c045504d1cff34ec9e8a6648e8ef4f335ae5b943f887f842a02b977c12979aed6688323f70e2d5ca9e2640fe14bf0a5e26ddfac95134d9c09ea02c204a0405fb9c3cb890219c6fccff0a9a265415656c5896449884c6a64caedef841a00104c001661c0169aac0fb16db9f30b70f8e13da88c539904b61895d3494c7889fca145e3f25f772c7e951708a541d8d14bb923edea351eeb0bbc928ae5b798508a0676a73762570ea5c17427aed9db14a85b268fafc282cbbe0c3db9165487133c9b84118cf5bd976613bb6a63009b15613d137f2555d2418da654a11781ac2cf5bf2fb63d44a580d2f15628f4b1cdb9526e1f774360b8ef2e5e451f18a80411d06b42b01c1808080e5a05e27869d58bd1fe21f34d0e9120abe775896df7c0829cf4d870f576f188cbe30838a8d05f90162c0c0f888f842a02099209289cdb7e5087d0401996d2fd9b52ce5cae39c547a039f126371a7f9bca026139d9d30188c9d52468ce9dfb48c39d552243611d5b270f5497c2b8692c696f842a02b2dabbf32c0cb551d3ba9159ae5c985ebcd71d79b00fabd26a74d618065bfd6a01bef832bd3efaea9f61c0582fb123bb547546f0c5910a9dda96bcd0063d57a02f888f842a027b90b5da16ef02417ad5820223e680d2c2d19a3f1d30566cfbb7b9aa30abf6da022432d9b57d271b8dd84bfb4ccd9df36b84e422cb471b35d50d55ae83a03f16ef842a0018ed79d6c0707cc6f4ec81bcea6c4cc0096f0e3635961caf3271c3c9a36a9dfa0179360dc4646a7c49bf730e1789c00622facd7836faa3c747be0f2d824cb1412f841a02147a377c426a6b91bd27342dfe180882d130d9fbbdcb147477f025082135c189f468884960c4e83243b3aeb52ef2eb017fa81ec4b98f63bedc7c1dc27ec0bfec20705c20805c2c0c0820001";
+
+    pub(crate) fn default_test_preimage_source() -> EigenDAPreimageSource<TestEigenDAPreimageSource>
+    {
+        let preimage_provider = test_utils::TestEigenDAPreimageSource::default();
+        EigenDAPreimageSource::new(preimage_provider)
+    }
+
+    #[test]
+    fn test_parse_altda_commitment() {
+        let mut preimage_source = default_test_preimage_source();
+        struct Case {
+            input: vec::Vec<u8>,
+            result: Result<(), HokuleaStatelessError>,
+        }
+        let cases = [
+            // not long enough such that there is no bytes for altda commitment
+            Case {
+                input: vec![1],
+                result: Err(HokuleaStatelessError::InsufficientLengthAltDACommimtment),
+            },
+            // invalid altda commitment to cover the altda commitment header
+            Case {
+                input: vec![1, 1, 1],
+                result: Err(HokuleaStatelessError::ParseError(
+                    AltDACommitmentParseError::InsufficientData,
+                )),
+            },
+            // 0x01 (OP derivation version byte) ++ valid altda commitment
+            Case {
+                input: hex::decode(CALLDATA_HEX).unwrap(),
+                result: Ok(()),
+            },
+        ];
+
+        for case in cases {
+            if let Err(e) = preimage_source.parse(&case.input.into()) {
+                assert_eq!(Err(e), case.result)
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_next() {
+        let calldata = hex::decode(CALLDATA_HEX).unwrap().into();
+        let mut preimage_source = default_test_preimage_source();
+        let altda_commitment = preimage_source.parse(&calldata).unwrap();
+        let rbn = altda_commitment.get_rbn();
+        let l1_inclusion_number = rbn + 100;
+        let encoded_payload: Bytes = vec![
+            0, 0, 0, 0, 0, 31, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+            2, 2, 2, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1,
+        ]
+        .into();
+
+        struct Case {
+            recency: Result<u64, TestHokuleaProviderError>,
+            validity: Result<bool, TestHokuleaProviderError>,
+            encoded_payload: Result<EncodedPayload, TestHokuleaProviderError>,
+            result: Result<EncodedPayload, HokuleaErrorKind>,
+        }
+
+        let cases = [
+            // not recent enough
+            Case {
+                // l1_inclusion_number = rbn + 100 > rbn + 10
+                recency: Ok(10),
+                // below are ignored
+                validity: Ok(false),
+                encoded_payload: Ok(EncodedPayload::default()),
+                result: Err(HokuleaPreimageError::NotRecentCert.into()),
+            },
+            // not valid
+            Case {
+                // l1_inclusion_number = rbn + 100 < rbn + 200
+                recency: Ok(200),
+                validity: Ok(false),
+                // below are ignored
+                encoded_payload: Ok(EncodedPayload::default()),
+                result: Err(HokuleaPreimageError::InvalidCert.into()),
+            },
+            // working
+            Case {
+                recency: Ok(200),
+                validity: Ok(true),
+                encoded_payload: Ok(EncodedPayload {
+                    encoded_payload: encoded_payload.clone(),
+                }),
+                result: Ok(EncodedPayload {
+                    encoded_payload: encoded_payload.clone(),
+                }),
+            },
+            // recency preimage has a critical problem
+            Case {
+                recency: Err(TestHokuleaProviderError::InvalidHokuleaPreimageQueryResponse),
+                // below are ignored
+                validity: Ok(false),
+                encoded_payload: Ok(EncodedPayload {
+                    encoded_payload: encoded_payload.clone(),
+                }),
+                result: Err(HokuleaErrorKind::Critical(
+                    "Invalid hokulea preimage response".to_string(),
+                )),
+            },
+            // recency preimage has a temporary problem
+            Case {
+                recency: Err(TestHokuleaProviderError::Preimage),
+                // below are ignored
+                validity: Ok(false),
+                encoded_payload: Ok(EncodedPayload {
+                    encoded_payload: encoded_payload.clone(),
+                }),
+                result: Err(HokuleaErrorKind::Temporary(
+                    "Preimage temporary error".to_string(),
+                )),
+            },
+            // validity preimage has a critical problem
+            Case {
+                recency: Ok(200),
+                validity: Err(TestHokuleaProviderError::InvalidHokuleaPreimageQueryResponse),
+                // below are ignored
+                encoded_payload: Ok(EncodedPayload {
+                    encoded_payload: encoded_payload.clone(),
+                }),
+                result: Err(HokuleaErrorKind::Critical(
+                    "Invalid hokulea preimage response".to_string(),
+                )),
+            },
+            // recency preimage has a temporary problem
+            Case {
+                recency: Ok(200),
+                validity: Err(TestHokuleaProviderError::Preimage),
+                // below are ignored
+                encoded_payload: Ok(EncodedPayload {
+                    encoded_payload: encoded_payload.clone(),
+                }),
+                result: Err(HokuleaErrorKind::Temporary(
+                    "Preimage temporary error".to_string(),
+                )),
+            },
+            // encoded payload preimage has a critical problem
+            Case {
+                recency: Ok(200),
+                validity: Ok(true),
+                encoded_payload: Err(TestHokuleaProviderError::InvalidHokuleaPreimageQueryResponse),
+                result: Err(HokuleaErrorKind::Critical(
+                    "Invalid hokulea preimage response".to_string(),
+                )),
+            },
+            // encoded payload preimage has a temporary problem
+            Case {
+                recency: Ok(200),
+                validity: Ok(true),
+                encoded_payload: Err(TestHokuleaProviderError::Preimage),
+                result: Err(HokuleaErrorKind::Temporary(
+                    "Preimage temporary error".to_string(),
+                )),
+            },
+        ];
+
+        for case in cases {
+            // set up preimage
+            preimage_source
+                .eigenda_fetcher
+                .insert_recency(&altda_commitment, case.recency);
+            preimage_source
+                .eigenda_fetcher
+                .insert_validity(&altda_commitment, case.validity);
+            preimage_source
+                .eigenda_fetcher
+                .insert_encoded_payload(&altda_commitment, case.encoded_payload);
+
+            match preimage_source.next(&calldata, l1_inclusion_number).await {
+                Ok(encoded_payload) => assert_eq!(encoded_payload, case.result.unwrap()),
+                Err(e) => assert_eq!(Err(e), case.result),
+            }
+        }
+    }
+}

--- a/crates/eigenda/src/errors.rs
+++ b/crates/eigenda/src/errors.rs
@@ -85,7 +85,7 @@ pub enum EncodedPayloadDecodingError {
 /// A list of Hokulea error derived from data from preimage oracle
 /// This error is intended for application logics, and it is separate from
 /// the more basic error type that deals with Provider error like
-/// [HokuleaOracleProviderError] which hanldes communicates, response format
+/// HokuleaOracleProviderError which hanldes communicates and response format
 /// error
 #[derive(Debug, thiserror::Error, PartialEq)]
 #[error(transparent)]

--- a/crates/eigenda/src/errors.rs
+++ b/crates/eigenda/src/errors.rs
@@ -1,4 +1,4 @@
-//! High level Error type defined by hokulea
+//! High level application error type for eigenda blob derivation
 
 use alloc::string::{String, ToString};
 use eigenda_cert::AltDACommitmentParseError;
@@ -17,10 +17,10 @@ pub enum HokuleaErrorKind {
     Temporary(String),
 }
 
-/// A list of Hokulea application error purely out of data processing.
-/// They are at the same level as preimage error, except those error
-/// does not depends on the state returned from the preimage oracle.
-/// Those are higher level errors than provider error
+/// Both [HokuleaStatelessError] and [HokuleaPreimageError] defined at the bottom
+/// represents all application error for hokulea. The [HokuleaStatelessError] is
+/// different that the errors comes from pure data processing of altDA commitment
+/// and encoded payload
 #[derive(Debug, thiserror::Error, PartialEq)]
 #[error(transparent)]
 pub enum HokuleaStatelessError {
@@ -82,11 +82,11 @@ pub enum EncodedPayloadDecodingError {
     },
 }
 
-/// A list of Hokulea error derived from data from preimage oracle
-/// This error is intended for application logics, and it is separate from
-/// the more basic error type that deals with Provider error like
-/// HokuleaOracleProviderError which hanldes communicates and response format
-/// error
+/// The [HokuleaPreimageError] contains application errors, that is directly relates
+/// to the preimage returned by the preimage provider. There is no error for
+/// EncodedPayload which is also a preimage, because EncodedPayload is only a vector
+/// of bytes, but its decoding check is covered by [HokuleaStatelessError] in the data
+/// processing stage.
 #[derive(Debug, thiserror::Error, PartialEq)]
 #[error(transparent)]
 pub enum HokuleaPreimageError {

--- a/crates/eigenda/src/lib.rs
+++ b/crates/eigenda/src/lib.rs
@@ -35,6 +35,9 @@ pub use errors::{
     EncodedPayloadDecodingError, HokuleaErrorKind, HokuleaPreimageError, HokuleaStatelessError,
 };
 
+#[cfg(test)]
+mod test_utils;
+
 mod constant;
 pub use constant::BYTES_PER_FIELD_ELEMENT;
 pub use constant::ENCODED_PAYLOAD_HEADER_LEN_BYTES;

--- a/crates/eigenda/src/test_utils.rs
+++ b/crates/eigenda/src/test_utils.rs
@@ -1,0 +1,108 @@
+//! An implementation of the [EigenDAPreimageProvider] trait for tests.
+
+use crate::errors::HokuleaErrorKind;
+use crate::{EigenDAPreimageProvider, EncodedPayload};
+use alloy_primitives::{map::HashMap, B256};
+use eigenda_cert::AltDACommitment;
+
+use alloc::boxed::Box;
+use alloc::string::ToString;
+use async_trait::async_trait;
+
+/// Custom hokulea preimage error
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum TestHokuleaProviderError {
+    /// Preimage returned something, but the returned value is invalid
+    #[error("Invalid Cert query response")]
+    InvalidHokuleaPreimageQueryResponse,
+    /// Preimage Oracle error from kona
+    /// <https://github.com/op-rs/kona/blob/174b2ac5ad3756d4469553c7777b04056f9d151c/crates/proof/proof/src/errors.rs#L18>
+    #[error("Preimage oracle error")]
+    Preimage,
+}
+
+impl From<TestHokuleaProviderError> for HokuleaErrorKind {
+    fn from(val: TestHokuleaProviderError) -> Self {
+        match val {
+            TestHokuleaProviderError::InvalidHokuleaPreimageQueryResponse => {
+                HokuleaErrorKind::Critical("Invalid hokulea preimage response".to_string())
+            }
+            // in kona, all Preimage error are grouped into backend error <https://github.com/op-rs/kona/blob/4ef01882824b84d078ead9f834f4f78213dd6ef3/crates/protocol/derive/src/sources/blobs.rs#L136>
+            // which is considered a temp issue
+            TestHokuleaProviderError::Preimage => {
+                HokuleaErrorKind::Temporary("Preimage temporary error".to_string())
+            }
+        }
+    }
+}
+
+// a mock object implements the EigenDAPreimageProvider trait
+#[derive(Debug, Clone, Default)]
+pub(crate) struct TestEigenDAPreimageSource {
+    recencies: HashMap<B256, Result<u64, TestHokuleaProviderError>>,
+    validities: HashMap<B256, Result<bool, TestHokuleaProviderError>>,
+    encoded_payloads: HashMap<B256, Result<EncodedPayload, TestHokuleaProviderError>>,
+}
+
+impl TestEigenDAPreimageSource {
+    pub(crate) fn insert_recency(
+        &mut self,
+        altda_commitment: &AltDACommitment,
+        recency: Result<u64, TestHokuleaProviderError>,
+    ) {
+        self.recencies.insert(altda_commitment.to_digest(), recency);
+    }
+
+    pub(crate) fn insert_validity(
+        &mut self,
+        altda_commitment: &AltDACommitment,
+        validity: Result<bool, TestHokuleaProviderError>,
+    ) {
+        self.validities
+            .insert(altda_commitment.to_digest(), validity);
+    }
+
+    pub(crate) fn insert_encoded_payload(
+        &mut self,
+        altda_commitment: &AltDACommitment,
+        encoded_payload: Result<EncodedPayload, TestHokuleaProviderError>,
+    ) {
+        self.encoded_payloads
+            .insert(altda_commitment.to_digest(), encoded_payload);
+    }
+}
+
+#[async_trait]
+impl EigenDAPreimageProvider for TestEigenDAPreimageSource {
+    type Error = TestHokuleaProviderError;
+
+    async fn get_recency_window(
+        &mut self,
+        altda_commitment: &AltDACommitment,
+    ) -> Result<u64, Self::Error> {
+        self.recencies
+            .get(&altda_commitment.to_digest())
+            .unwrap()
+            .clone()
+    }
+
+    async fn get_validity(
+        &mut self,
+        altda_commitment: &AltDACommitment,
+    ) -> Result<bool, Self::Error> {
+        self.validities
+            .get(&altda_commitment.to_digest())
+            .unwrap()
+            .clone()
+    }
+
+    async fn get_encoded_payload(
+        &mut self,
+        altda_commitment: &AltDACommitment,
+    ) -> Result<EncodedPayload, Self::Error> {
+        self.encoded_payloads
+            .get(&altda_commitment.to_digest())
+            .unwrap()
+            .clone()
+    }
+}

--- a/crates/proof/src/eigenda_provider.rs
+++ b/crates/proof/src/eigenda_provider.rs
@@ -63,7 +63,7 @@ impl<T: CommsClient + Sync + Send> EigenDAPreimageProvider for OracleEigenDAPrei
 
         // recency is 8 bytes
         if recency_bytes.is_empty() || recency_bytes.len() != 8 {
-            return Err(HokuleaOracleProviderError::InvalidCertQueryResponse);
+            return Err(HokuleaOracleProviderError::InvalidHokuleaPreimageQueryResponse);
         }
 
         let mut buf: [u8; 8] = [0; 8];
@@ -102,13 +102,13 @@ impl<T: CommsClient + Sync + Send> EigenDAPreimageProvider for OracleEigenDAPrei
 
         // validity is expected as a boolean
         if validity.is_empty() || validity.len() != 1 {
-            return Err(HokuleaOracleProviderError::InvalidCertQueryResponse);
+            return Err(HokuleaOracleProviderError::InvalidHokuleaPreimageQueryResponse);
         }
 
         match validity[0] {
             0 => Ok(false),
             1 => Ok(true),
-            _ => Err(HokuleaOracleProviderError::InvalidCertQueryResponse),
+            _ => Err(HokuleaOracleProviderError::InvalidHokuleaPreimageQueryResponse),
         }
     }
 

--- a/crates/proof/src/errors.rs
+++ b/crates/proof/src/errors.rs
@@ -5,12 +5,9 @@ use kona_preimage::errors::PreimageOracleError;
 /// Custom hokulea preimage error
 #[derive(Debug, thiserror::Error)]
 pub enum HokuleaOracleProviderError {
-    /// Invalid Cert validity response
+    /// Preimage returned something, but the returned value is invalid
     #[error("Invalid Cert query response")]
-    InvalidCertQueryResponse,
-    /// Preimage informs the client that DA cert is wrong
-    #[error("Invalid DA certificate")]
-    InvalidCert,
+    InvalidHokuleaPreimageQueryResponse,
     /// Preimage Oracle error from kona
     /// <https://github.com/op-rs/kona/blob/174b2ac5ad3756d4469553c7777b04056f9d151c/crates/proof/proof/src/errors.rs#L18>
     #[error("Preimage oracle error: {0}")]
@@ -20,11 +17,8 @@ pub enum HokuleaOracleProviderError {
 impl From<HokuleaOracleProviderError> for HokuleaErrorKind {
     fn from(val: HokuleaOracleProviderError) -> Self {
         match val {
-            HokuleaOracleProviderError::InvalidCertQueryResponse => {
+            HokuleaOracleProviderError::InvalidHokuleaPreimageQueryResponse => {
                 HokuleaErrorKind::Critical("Invalid certificate response".to_string())
-            }
-            HokuleaOracleProviderError::InvalidCert => {
-                HokuleaErrorKind::Discard("Invalid certificate".to_string())
             }
             // in kona, all Preimage error are grouped into backend error <https://github.com/op-rs/kona/blob/4ef01882824b84d078ead9f834f4f78213dd6ef3/crates/protocol/derive/src/sources/blobs.rs#L136>
             // which is considered a temp issue


### PR DESCRIPTION
This PR creates a mock object implementing EigenDAPreimageProvider trait.

This PR also adds unit tests for eigenda_preimage.rs. 

This PR also renames some error and delete unused errors type in an enum.