### PR TITLE
chores: improve logging for 0 canoe proof generation

### DIFF
--- a/crates/witgen/src/canoe_witness_provider.rs
+++ b/crates/witgen/src/canoe_witness_provider.rs
@@ -40,7 +40,11 @@ where
 
     let mut canoe_inputs = vec![];
 
-    info!(target: "canoe witness provider", "producing 1 canoe proof for {} DA certs", wit.validities.len());
+    if wit.validities.is_empty() {
+        info!(target: "canoe witness provider", "no DA certs to process, skipping canoe proof generation");
+    } else {
+        info!(target: "canoe witness provider", "producing 1 canoe proof for {} DA certs", wit.validities.len());
+    }
 
     for (altda_commitment, cert_validity) in &mut wit.validities {
         let canoe_input = CanoeInput {


### PR DESCRIPTION
I noticed a log message `producing 1 canoe proof for 0 DA certs` while testing EthDA proving, though canoe proof generation was skipped. This PR improves the logging for cases where canoe proof generation is skipped, making it clearer and based on DA cert availability.