### PR TITLE
feat: abstract address getter and cleanup canoe verifier

### DIFF
--- a/crates/proof/src/canoe_verifier/address_fetcher.rs
+++ b/crates/proof/src/canoe_verifier/address_fetcher.rs
@@ -83,13 +83,17 @@ fn cert_verifier_address_abi_encode_interface(
         // if user uses a different private key, or nonce for deployment are different from
         // the default, the address below would change
         3151908 => Ok(address!("0xb4B46bdAA835F8E4b4d8e208B6559cD267851051")),
-        chain_id => Err(CanoeVerifierAddressFetcherError::UnknownChainIDForABIEncodeInterface(chain_id)),
+        chain_id => {
+            Err(CanoeVerifierAddressFetcherError::UnknownChainIDForABIEncodeInterface(chain_id))
+        }
     }
 }
 
 /// legacy interface
 /// <https://github.com/Layr-Labs/eigenda/blob/bf714cb07fc2dee8b8c8ad7fb6043f9a030f7550/contracts/src/integrations/cert/legacy/IEigenDACertVerifierLegacy.sol#L62>
-fn cert_verifier_legacy_v2_interface(chain_id: u64) -> Result<Address, CanoeVerifierAddressFetcherError> {
+fn cert_verifier_legacy_v2_interface(
+    chain_id: u64,
+) -> Result<Address, CanoeVerifierAddressFetcherError> {
     // this is kurtosis devnet
     match chain_id {
         // Sepolia V2 cert verifier address
@@ -103,8 +107,8 @@ fn cert_verifier_legacy_v2_interface(chain_id: u64) -> Result<Address, CanoeVeri
         // if user uses a different private key, or nonce for deployment are different from
         // the default, the address below would change
         3151908 => Ok(address!("0xb4B46bdAA835F8E4b4d8e208B6559cD267851051")),
-        chain_id => Err(CanoeVerifierAddressFetcherError::UnknownChainIDForLegacyInterface(
-            chain_id,
-        )),
+        chain_id => {
+            Err(CanoeVerifierAddressFetcherError::UnknownChainIDForLegacyInterface(chain_id))
+        }
     }
 }

--- a/crates/proof/src/canoe_verifier/address_fetcher.rs
+++ b/crates/proof/src/canoe_verifier/address_fetcher.rs
@@ -7,7 +7,9 @@ pub enum CanoeVerifierAddressFetcherError {
     #[error("Unable to fetch contract address at chain id {0} for abi encode interface, available for router and at least V3 certificate")]
     UnknownChainIDForABIEncodeInterface(u64),
     /// Cannot fetch address for chainID for legacy interface
-    #[error("Unable to fetch contract address at chain id {0} for legacy interface for V2 certificate")]
+    #[error(
+        "Unable to fetch contract address at chain id {0} for legacy interface for V2 certificate"
+    )]
     UnknownChainIDForLegacyInterface(u64),
 }
 

--- a/crates/proof/src/canoe_verifier/address_fetcher.rs
+++ b/crates/proof/src/canoe_verifier/address_fetcher.rs
@@ -3,11 +3,11 @@ use eigenda_cert::EigenDAVersionedCert;
 
 #[derive(Debug, thiserror::Error)]
 pub enum CanoeVerifierAddressFetcherError {
-    /// Cannot fetch address for chainID
-    #[error("Unable to fetch contract address at in chain id {0} for abi encode interface, available for router and at least V3 certificate")]
+    /// Cannot fetch address for chainID for abi encoding interface
+    #[error("Unable to fetch contract address at chain id {0} for abi encode interface, available for router and at least V3 certificate")]
     UnknownChainIDForABIEncodeInterface(u64),
-    /// Invalid Cert validity response
-    #[error("Unable to fetch contract address at in chain id {0} for legacy interface for V2 certificate")]
+    /// Cannot fetch address for chainID for legacy interface
+    #[error("Unable to fetch contract address at chain id {0} for legacy interface for V2 certificate")]
     UnknownChainIDForLegacyInterface(u64),
 }
 

--- a/crates/proof/src/canoe_verifier/address_fetcher.rs
+++ b/crates/proof/src/canoe_verifier/address_fetcher.rs
@@ -1,0 +1,110 @@
+use alloy_primitives::{address, Address};
+use eigenda_cert::EigenDAVersionedCert;
+
+#[derive(Debug, thiserror::Error)]
+pub enum CanoeVerifierAddressFetcherError {
+    /// Cannot fetch address for chainID
+    #[error("Unable to fetch contract address at in chain id {0} for abi encode interface, available for router and at least V3 certificate")]
+    UnknownChainIDForABIEncodeInterface(u64),
+    /// Invalid Cert validity response
+    #[error("Unable to fetch contract address at in chain id {0} for legacy interface for V2 certificate")]
+    UnknownChainIDForLegacyInterface(u64),
+}
+
+pub trait CanoeVerifierAddressFetcher: Clone + Send + 'static {
+    /// fetch address for canoe verifier
+    fn fetch_address(
+        &self,
+        chain_id: u64,
+        versioned_cert: &EigenDAVersionedCert,
+    ) -> Result<Address, CanoeVerifierAddressFetcherError>;
+}
+
+#[derive(Clone)]
+pub struct CanoeNoOpCanoeVerifierAddressFetcher {}
+
+impl CanoeVerifierAddressFetcher for CanoeNoOpCanoeVerifierAddressFetcher {
+    fn fetch_address(
+        &self,
+        _chain_id: u64,
+        _versioned_cert: &EigenDAVersionedCert,
+    ) -> Result<Address, CanoeVerifierAddressFetcherError> {
+        Ok(Address::default())
+    }
+}
+
+#[derive(Clone)]
+pub struct CanoeVerifierAddressFetcherDeployedByEigenLabs {}
+
+impl CanoeVerifierAddressFetcher for CanoeVerifierAddressFetcherDeployedByEigenLabs {
+    // From V3 certificate and forward, Eigenlabs uses the address router implementation, which automatically picks the right
+    // verification logics inside the smart contract based on reference block number(rbn) stored inside the Abi encoded cert.
+    // For users that does not want a router, you can still implements the routing logics offchain by inspecting the rbn within
+    // the EigenDAVersionedCert
+    fn fetch_address(
+        &self,
+        chain_id: u64,
+        versioned_cert: &EigenDAVersionedCert,
+    ) -> Result<Address, CanoeVerifierAddressFetcherError> {
+        cert_verifier_address(chain_id, versioned_cert)
+    }
+}
+
+/// get cert verifier address based on chain id, and cert version from altda commitment
+/// V3 cert uses router address
+fn cert_verifier_address(
+    chain_id: u64,
+    versioned_cert: &EigenDAVersionedCert,
+) -> Result<Address, CanoeVerifierAddressFetcherError> {
+    match &versioned_cert {
+        EigenDAVersionedCert::V2(_) => cert_verifier_legacy_v2_interface(chain_id),
+        EigenDAVersionedCert::V3(_) => cert_verifier_address_abi_encode_interface(chain_id),
+    }
+}
+
+/// for smart contract functions that only accepts bytes
+/// this pattern is adopted since V3 certificate and address router implementation
+/// <https://github.com/Layr-Labs/eigenda/blob/bf714cb07fc2dee8b8c8ad7fb6043f9a030f7550/contracts/src/integrations/cert/interfaces/IEigenDACertVerifierBase.sol#L11>
+fn cert_verifier_address_abi_encode_interface(
+    chain_id: u64,
+) -> Result<Address, CanoeVerifierAddressFetcherError> {
+    // this is kurtosis devnet
+    match chain_id {
+        // mainnet
+        1 => Ok(address!("0x61692e93b6B045c444e942A91EcD1527F23A3FB7")),
+        // Sepolia router cert verifier address
+        11155111 => Ok(address!("0x58D2B844a894f00b7E6F9F492b9F43aD54Cd4429")),
+        // holesky router cert verifier address
+        17000 => Ok(address!("0xDD735AFFe77A5ED5b21ED47219f95ED841f8Ffbd")),
+        // kurtosis l1 chain id => mock contract address
+        // This is the cert verifier that canoe provider and verifier are run against.
+        // In hokulea repo, there is a mock contract under canoe directory, which can be
+        // deployed to generate the address and test functionality.
+        // if user uses a different private key, or nonce for deployment are different from
+        // the default, the address below would change
+        3151908 => Ok(address!("0xb4B46bdAA835F8E4b4d8e208B6559cD267851051")),
+        chain_id => Err(CanoeVerifierAddressFetcherError::UnknownChainIDForABIEncodeInterface(chain_id)),
+    }
+}
+
+/// legacy interface
+/// <https://github.com/Layr-Labs/eigenda/blob/bf714cb07fc2dee8b8c8ad7fb6043f9a030f7550/contracts/src/integrations/cert/legacy/IEigenDACertVerifierLegacy.sol#L62>
+fn cert_verifier_legacy_v2_interface(chain_id: u64) -> Result<Address, CanoeVerifierAddressFetcherError> {
+    // this is kurtosis devnet
+    match chain_id {
+        // Sepolia V2 cert verifier address
+        11155111 => Ok(address!("0x73818fed0743085c4557a736a7630447fb57c662")),
+        // holesky V2 cert verifier address
+        17000 => Ok(address!("0xFe52fE1940858DCb6e12153E2104aD0fDFbE1162")),
+        // kurtosis l1 chain id => mock contract address
+        // This is the cert verifier that canoe provider and verifier are run against.
+        // In hokulea repo, there is a mock contract under canoe directory, which can be
+        // deployed to generate the address and test functionality.
+        // if user uses a different private key, or nonce for deployment are different from
+        // the default, the address below would change
+        3151908 => Ok(address!("0xb4B46bdAA835F8E4b4d8e208B6559cD267851051")),
+        chain_id => Err(CanoeVerifierAddressFetcherError::UnknownChainIDForLegacyInterface(
+            chain_id,
+        )),
+    }
+}

--- a/crates/proof/src/canoe_verifier/errors.rs
+++ b/crates/proof/src/canoe_verifier/errors.rs
@@ -6,10 +6,8 @@ use alloc::string::String;
 /// sp1 cannot take sp1-sdk as dependency which is needed for verification in non zkvm mode
 #[derive(Debug, thiserror::Error)]
 pub enum HokuleaCanoeVerificationError {
-    /// InconsistentPublicJournal
     #[error("Non zkvm environment: inconsistency between public journal proven by the zk proof and user supplied journal")]
     InconsistentPublicJournal,
-    /// MissingProof
     #[error("Non zkvm environment: proof is missing")]
     MissingProof,
     /// Invalid Cert validity response. To avoid taking dep on specific zkVM error message, we convert them into string

--- a/crates/proof/src/canoe_verifier/errors.rs
+++ b/crates/proof/src/canoe_verifier/errors.rs
@@ -6,9 +6,6 @@ use alloc::string::String;
 /// sp1 cannot take sp1-sdk as dependency which is needed for verification in non zkvm mode
 #[derive(Debug, thiserror::Error)]
 pub enum HokuleaCanoeVerificationError {
-    /// Cannot fetch address for chainID
-    #[error("Unable to fetch contract address which verifies in chain id {0} at reference block number {1}")]
-    UnableToFetchContractAddress(u64, u32),
     /// Invalid Cert validity response
     #[error("Non zkvm environment: inconsistency between public journal proven by the zk proof and user supplied journal")]
     InconsistentPublicJournal,
@@ -21,7 +18,4 @@ pub enum HokuleaCanoeVerificationError {
     /// unable to deserialize receipt
     #[error("Non zkvm environment: unable to deserialize receipt: {0}")]
     UnableToDeserializeReceipt(String),
-    /// an invalid verification key for sp1
-    #[error("Invalid verification key for Sp1")]
-    InvalidVerificationKeyForSp1,
 }

--- a/crates/proof/src/canoe_verifier/errors.rs
+++ b/crates/proof/src/canoe_verifier/errors.rs
@@ -6,10 +6,10 @@ use alloc::string::String;
 /// sp1 cannot take sp1-sdk as dependency which is needed for verification in non zkvm mode
 #[derive(Debug, thiserror::Error)]
 pub enum HokuleaCanoeVerificationError {
-    /// Invalid Cert validity response
+    /// InconsistentPublicJournal
     #[error("Non zkvm environment: inconsistency between public journal proven by the zk proof and user supplied journal")]
     InconsistentPublicJournal,
-    /// Invalid Cert validity response
+    /// MissingProof
     #[error("Non zkvm environment: proof is missing")]
     MissingProof,
     /// Invalid Cert validity response. To avoid taking dep on specific zkVM error message, we convert them into string

--- a/crates/proof/src/canoe_verifier/errors.rs
+++ b/crates/proof/src/canoe_verifier/errors.rs
@@ -6,6 +6,9 @@ use alloc::string::String;
 /// sp1 cannot take sp1-sdk as dependency which is needed for verification in non zkvm mode
 #[derive(Debug, thiserror::Error)]
 pub enum HokuleaCanoeVerificationError {
+    /// Cannot fetch address for chainID
+    #[error("Unable to fetch contract address which verifies in chain id {0} at reference block number {1}")]
+    UnableToFetchContractAddress(u64, u32),
     /// Invalid Cert validity response
     #[error("Non zkvm environment: inconsistency between public journal proven by the zk proof and user supplied journal")]
     InconsistentPublicJournal,

--- a/crates/proof/src/canoe_verifier/mod.rs
+++ b/crates/proof/src/canoe_verifier/mod.rs
@@ -1,3 +1,4 @@
+pub mod address_fetcher;
 pub mod errors;
 pub mod noop;
 #[cfg(feature = "steel")]
@@ -8,11 +9,10 @@ pub mod sp1_cc;
 
 use crate::cert_validity::CertValidity;
 use alloc::vec::Vec;
-use alloy_primitives::{address, Address};
 use alloy_sol_types::SolValue;
 use canoe_bindings::Journal;
 
-use eigenda_cert::{AltDACommitment, EigenDAVersionedCert};
+use eigenda_cert::AltDACommitment;
 
 pub trait CanoeVerifier: Clone + Send + 'static {
     fn validate_cert_receipt(
@@ -20,73 +20,29 @@ pub trait CanoeVerifier: Clone + Send + 'static {
         _cert_validity_pair: Vec<(AltDACommitment, CertValidity)>,
         _canoe_proof: Option<Vec<u8>>,
     ) -> Result<(), errors::HokuleaCanoeVerificationError>;
-}
 
-/// A helper function to convert validity and eigenda_cert into journals.
-/// Those journals are concatenated in a serialized byte array which is then committed by the zkVM.
-/// The zkVM host is expected to provide a zk proof that commites to those serialized bytes array.
-/// Those bytes are never expected to be deserialized.
-pub fn to_journals_bytes(cert_validity_pairs: Vec<(AltDACommitment, CertValidity)>) -> Vec<u8> {
-    let mut journals: Vec<u8> = Vec::new();
-    for (altda_commitment, cert_validity) in &cert_validity_pairs {
-        let rlp_bytes = altda_commitment.to_rlp_bytes();
+    /// The function converts validity and altda commitment into journals.
+    /// Journals are concatenated in a serialized byte array. The output of
+    /// the serialization must be identical to one committed by zkVM.
+    /// Those bytes are never expected to be deserialized.
+    fn to_journals_bytes(
+        &self,
+        cert_validity_pairs: Vec<(AltDACommitment, CertValidity)>,
+    ) -> Vec<u8> {
+        let mut journals: Vec<u8> = Vec::new();
+        for (altda_commitment, cert_validity) in &cert_validity_pairs {
+            let rlp_bytes = altda_commitment.to_rlp_bytes();
 
-        let journal = Journal {
-            certVerifierAddress: cert_verifier_address(cert_validity.l1_chain_id, altda_commitment),
-            input: rlp_bytes.into(),
-            blockhash: cert_validity.l1_head_block_hash,
-            output: cert_validity.claimed_validity,
-            l1ChainId: cert_validity.l1_chain_id,
-        };
+            let journal = Journal {
+                certVerifierAddress: cert_validity.verifier_address,
+                input: rlp_bytes.into(),
+                blockhash: cert_validity.l1_head_block_hash,
+                output: cert_validity.claimed_validity,
+                l1ChainId: cert_validity.l1_chain_id,
+            };
 
-        journals.extend(journal.abi_encode());
-    }
-    journals
-}
-
-/// get cert verifier address based on chain id, and cert version from altda commitment
-/// V3 cert uses router address
-pub fn cert_verifier_address(chain_id: u64, altda_commitment: &AltDACommitment) -> Address {
-    match &altda_commitment.versioned_cert {
-        EigenDAVersionedCert::V2(_) => cert_verifier_v2_address(chain_id),
-        EigenDAVersionedCert::V3(_) => cert_verifier_router_address(chain_id),
-    }
-}
-
-pub fn cert_verifier_router_address(chain_id: u64) -> Address {
-    // this is kurtosis devnet
-    match chain_id {
-        // mainnet
-        1 => address!("0x61692e93b6B045c444e942A91EcD1527F23A3FB7"),
-        // Sepolia router cert verifier address
-        11155111 => address!("0x58D2B844a894f00b7E6F9F492b9F43aD54Cd4429"),
-        // holesky router cert verifier address
-        17000 => address!("0xDD735AFFe77A5ED5b21ED47219f95ED841f8Ffbd"),
-        // kurtosis l1 chain id => mock contract address
-        // This is the cert verifier that canoe provider and verifier are run against.
-        // In hokulea repo, there is a mock contract under canoe directory, which can be
-        // deployed to generate the address and test functionality.
-        // if user uses a different private key, or nonce for deployment are different from
-        // the default, the address below would change
-        3151908 => address!("0xb4B46bdAA835F8E4b4d8e208B6559cD267851051"),
-        chain_id => panic!("chain id {} is unknown", chain_id),
-    }
-}
-
-pub fn cert_verifier_v2_address(chain_id: u64) -> Address {
-    // this is kurtosis devnet
-    match chain_id {
-        // Sepolia V2 cert verifier address
-        11155111 => address!("0x73818fed0743085c4557a736a7630447fb57c662"),
-        // holesky V2 cert verifier address
-        17000 => address!("0xFe52fE1940858DCb6e12153E2104aD0fDFbE1162"),
-        // kurtosis l1 chain id => mock contract address
-        // This is the cert verifier that canoe provider and verifier are run against.
-        // In hokulea repo, there is a mock contract under canoe directory, which can be
-        // deployed to generate the address and test functionality.
-        // if user uses a different private key, or nonce for deployment are different from
-        // the default, the address below would change
-        3151908 => address!("0xb4B46bdAA835F8E4b4d8e208B6559cD267851051"),
-        chain_id => panic!("chain id {} is unknown", chain_id),
+            journals.extend(journal.abi_encode());
+        }
+        journals
     }
 }

--- a/crates/proof/src/canoe_verifier/sp1_cc.rs
+++ b/crates/proof/src/canoe_verifier/sp1_cc.rs
@@ -47,7 +47,7 @@ impl CanoeVerifier for CanoeSp1CCVerifier {
                 use core::str::FromStr;
                 use crate::canoe_verifier::to_journals_bytes;
 
-                let journals_bytes = to_journals_bytes(cert_validity_pair);
+                let journals_bytes = CanoeVerifier::to_journals_bytes(self, cert_validity_pair);
 
                 // if not in dev mode, the receipt should be empty
                 if canoe_proof_bytes.is_some() {

--- a/crates/proof/src/canoe_verifier/steel.rs
+++ b/crates/proof/src/canoe_verifier/steel.rs
@@ -1,5 +1,5 @@
 use crate::canoe_verifier::errors::HokuleaCanoeVerificationError;
-use crate::canoe_verifier::{to_journals_bytes, CanoeVerifier};
+use crate::canoe_verifier::CanoeVerifier;
 use crate::cert_validity::CertValidity;
 use alloc::string::ToString;
 use alloc::vec::Vec;
@@ -27,7 +27,8 @@ impl CanoeVerifier for CanoeSteelVerifier {
     ) -> Result<(), HokuleaCanoeVerificationError> {
         info!("using CanoeSteelVerifier");
 
-        let journals_bytes = to_journals_bytes(cert_validity_pair);
+        // use default to_journals_bytes implementation
+        let journals_bytes = CanoeVerifier::to_journals_bytes(self, cert_validity_pair);
 
         cfg_if::cfg_if! {
             if #[cfg(target_os = "zkvm")] {

--- a/crates/proof/src/cert_validity.rs
+++ b/crates/proof/src/cert_validity.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::B256;
+use alloy_primitives::{Address, B256};
 use serde::{Deserialize, Serialize};
 
 /// The l1_head from the kona_cfg is chosen to anchor the view call.
@@ -18,4 +18,6 @@ pub struct CertValidity {
     /// is not available in this struct, we take assumptions that no two block number
     /// will contain the same block hash
     pub l1_chain_id: u64,
+    /// verfier address
+    pub verifier_address: Address,
 }

--- a/crates/witgen/src/canoe_witness_provider.rs
+++ b/crates/witgen/src/canoe_witness_provider.rs
@@ -2,7 +2,7 @@ use alloy_consensus::Header;
 use alloy_rlp::Decodable;
 use canoe_provider::{CanoeInput, CanoeProvider};
 use core::fmt::Debug;
-use hokulea_proof::canoe_verifier::cert_verifier_address;
+use hokulea_proof::canoe_verifier::address_fetcher::CanoeVerifierAddressFetcher;
 use hokulea_proof::eigenda_witness::EigenDAWitness;
 use kona_preimage::{CommsClient, PreimageKey};
 use kona_proof::{BootInfo, FlushableCache};
@@ -14,13 +14,15 @@ use tracing::info;
 /// and chain_id.
 ///
 /// If no canoe proof is needed, it returns Ok(None)
-pub async fn from_boot_info_to_canoe_proof<P, O>(
+pub async fn from_boot_info_to_canoe_proof<A, P, O>(
     boot_info: &BootInfo,
     witness: &EigenDAWitness,
     oracle: Arc<O>,
     canoe_provider: P,
+    canoe_address_fetcher: A,
 ) -> anyhow::Result<Option<P::Receipt>>
 where
+    A: CanoeVerifierAddressFetcher,
     P: CanoeProvider,
     O: CommsClient + FlushableCache + Send + Sync + Debug,
 {
@@ -49,7 +51,8 @@ where
             l1_head_block_hash: boot_info.l1_head,
             l1_head_block_number: l1_head_header.number,
             l1_chain_id,
-            verifier_address: cert_verifier_address(l1_chain_id, altda_commitment),
+            verifier_address: canoe_address_fetcher
+                .fetch_address(l1_chain_id, &altda_commitment.versioned_cert)?,
         };
         canoe_inputs.push(canoe_input);
     }

--- a/crates/witgen/src/witness_provider.rs
+++ b/crates/witgen/src/witness_provider.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{FixedBytes, B256};
+use alloy_primitives::{Address, FixedBytes, B256};
 use async_trait::async_trait;
 use eigenda_cert::AltDACommitment;
 use hokulea_compute_proof::compute_kzg_proof;
@@ -65,6 +65,7 @@ impl<T: EigenDAPreimageProvider + Send> EigenDAPreimageProvider
                     // the rest of the field needs to be supplied within zkVM
                     l1_head_block_hash: B256::ZERO,
                     l1_chain_id: 0,
+                    verifier_address: Address::default(),
                 };
 
                 witness


### PR DESCRIPTION
This PR abstract verifier address getter.

- both provider and verifier need to instantiate the CanoeVerifierAddressFetcher to learn about the address. Previously it was hardcoded
- after the change, a rollup can implement their own structure for specifying rollup deployed address
- We moved Address into CertValidity struct, because it opens the possibility for offchain routing, if a user does not want to use onchain router.