### PR TITLE
ci: rm unnecessary ref in ci causing elf.yml fail

### DIFF
--- a/.github/workflows/elf.yml
+++ b/.github/workflows/elf.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
       - name: Install SP1 toolchain
         run: |
           curl -L https://sp1.succinct.xyz | bash


### PR DESCRIPTION
## Problem 
See this [Pr](https://github.com/Layr-Labs/hokulea/pull/173)

and CI [error](https://github.com/Layr-Labs/hokulea/actions/runs/18160673153/job/51760995467)

this cannot checkout branch from another PR, instead we should use the detached head from the PR which is the github default