### PR TITLE
fix: relax alloy-consensus exact pins to semver ranges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,13 +56,13 @@ hokulea-registry = { path = "crates/registry", version = "0.1.0", default-featur
 eigenda-cert = { path = "crates/eigenda-cert" }
 
 # Alloy (Network)
-alloy-consensus = { version = "=1.6.3", default-features = false }
-alloy-genesis = { version = "=1.6.3", default-features = false }
+alloy-consensus = { version = "1.6.3", default-features = false }
+alloy-genesis = { version = "1.6.3", default-features = false }
 alloy-primitives = { version = "1.5.6", default-features = false }
-alloy-provider = { version = "=1.6.3", default-features = false }
+alloy-provider = { version = "1.6.3", default-features = false }
 alloy-rlp = { version = "0.3.13", default-features = false }
-alloy-rpc-client = { version = "=1.6.3", default-features = false }
-alloy-rpc-types = { version = "=1.6.3", default-features = false }
+alloy-rpc-client = { version = "1.6.3", default-features = false }
+alloy-rpc-types = { version = "1.6.3", default-features = false }
 alloy-sol-types = { version = "1.5.6", default-features = false }
 
 # Execution
@@ -73,7 +73,7 @@ revm = { version = "34.0.0", default-features = false }
 revm-primitives = { version = "21.0.2", default-features = false }
 
 # OP Alloy
-op-alloy-consensus = { version = "=0.23.1", default-features = false }
+op-alloy-consensus = { version = "0.23.1", default-features = false }
 
 # Reth
 reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3", default-features = false }


### PR DESCRIPTION
## Summary
Relax `alloy-consensus = "=1.6.3"` and `op-alloy-consensus = "=0.23.1"` exact pins to semver ranges (`"1.6.3"` and `"0.23.1"`).

## Why
The exact pins prevent downstream consumers (op-succinct) from resolving alloy 1.7.x (required by kona). Semver ranges allow cargo to unify versions across the dependency tree.

## Changes
- `alloy-consensus`: `"=1.6.3"` → `"1.6.3"`
- `op-alloy-consensus`: `"=0.23.1"` → `"0.23.1"`

That's it — 2 characters removed.

## Request
Please merge and cut a release tag (e.g. `hokulea-client/v1.1.7`) so op-succinct can reference it.