### PR TITLE
feat: add eigenda-cert/examples/commitment_to_abi.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3579,6 +3579,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives 1.5.6",
  "alloy-rlp",
+ "alloy-sol-types",
  "anyhow",
  "canoe-bindings",
  "rkyv",

--- a/crates/eigenda-cert/Cargo.toml
+++ b/crates/eigenda-cert/Cargo.toml
@@ -11,3 +11,6 @@ serde = { workspace = true, features = ["derive"] }
 canoe-bindings = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
+
+[dev-dependencies]
+alloy-sol-types = { workspace = true }

--- a/crates/eigenda-cert/examples/commitment_to_abi.rs
+++ b/crates/eigenda-cert/examples/commitment_to_abi.rs
@@ -1,0 +1,42 @@
+//! Converts an AltDA commitment hex to an ABI-encoded cert hex.
+//!
+//! ```sh
+//! echo "010002f908f8..." | cargo run --example commitment_to_abi -p eigenda-cert
+//! ```
+
+use alloy_primitives::Bytes;
+use alloy_sol_types::SolValue;
+use eigenda_cert::{AltDACommitment, EigenDACertV3, EigenDAVersionedCert};
+use std::{io::Read, str::FromStr};
+
+fn main() {
+    let bytes = {
+        let mut input = String::new();
+        std::io::stdin().read_to_string(&mut input).unwrap();
+        let raw = Bytes::from_str(input.trim()).expect("invalid hex input");
+        if raw.starts_with(&[0x01, 0x01, 0x00]) {
+            eprintln!("warning: input looks like batcher calldata; strip the leading version byte so it starts with 0x0100.");
+            raw.slice(1..)
+        } else {
+            raw
+        }
+    };
+
+    let comm = AltDACommitment::try_from(&bytes[..]).expect("failed to parse AltDA commitment");
+    let abi_bytes: Bytes = match comm.versioned_cert {
+        EigenDAVersionedCert::V2(v2) => {
+            // V2 is promoted to V3 for the verifier interface (same as verifier_caller.rs)
+            let v3 = EigenDACertV3 {
+                batch_header_v2: v2.batch_header_v2,
+                blob_inclusion_info: v2.blob_inclusion_info,
+                nonsigner_stake_and_signature: v2.nonsigner_stake_and_signature,
+                signed_quorum_numbers: v2.signed_quorum_numbers,
+            };
+            v3.to_sol().abi_encode().into()
+        }
+        EigenDAVersionedCert::V3(v3) => v3.to_sol().abi_encode().into(),
+        EigenDAVersionedCert::V4(v4) => v4.to_sol().abi_encode().into(),
+    };
+
+    println!("{abi_bytes}");
+}


### PR DESCRIPTION
This PR introduces an example binary that converts an AltDA commitment hex string into ABI-encoded format.

**Usage**

```
echo "0x010002f908f8..." | cargo run --example commitment_to_abi -p eigenda-cert
```

The binary reads the AltDA commitment hex from standard input and outputs the ABI-encoded result to standard output.

A practical use case is inspecting a Batcher transaction: copy its calldata, pipe it into this binary, and then use the resulting output with:

```
cast call $CERT_ROUTER checkDACert(bytes)(uint8).
```

---

Alternatively, you can paste the ABI-encoded output directly into the `abiEncodedCert` function on [Etherscan](https://etherscan.io/address/0x1be7258230250Bc6a4548F8D59d576a87D216C12#readProxyContract).


<img width="1788" height="1000" alt="image" src="https://github.com/user-attachments/assets/58ef7976-c7dc-472e-8d72-92bb58222fa6" />
