### PR TITLE
chorus: add eigenda witness from preimage unchecked and debug lines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2506,6 +2506,7 @@ dependencies = [
 name = "canoe-sp1-cc-host"
 version = "0.1.0"
 dependencies = [
+ "alloy-genesis",
  "alloy-primitives 1.5.6",
  "alloy-rpc-client",
  "alloy-rpc-types",
@@ -2515,7 +2516,7 @@ dependencies = [
  "bincode",
  "canoe-bindings",
  "canoe-provider",
- "rsp-primitives",
+ "serde_json",
  "sp1-cc-client-executor",
  "sp1-cc-host-executor",
  "sp1-hypercube",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2536,7 +2536,6 @@ dependencies = [
  "canoe-verifier",
  "cfg-if",
  "eigenda-cert",
- "rsp-primitives",
  "sha2 0.10.9",
  "sp1-cc-client-executor",
  "sp1-lib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,6 @@ canoe-sp1-cc-host = { path = "./canoe/sp1-cc/host", default-features = false }
 canoe-sp1-cc-verifier = { path = "./canoe/sp1-cc/verifier", default-features = false }
 
 # RSP and SP1-CC - update to tags once released
-rsp-primitives = { git = "https://github.com/succinctlabs/rsp", tag = "reth-1.9.3-sp1-6.1.0" }
 sp1-build = "=6.1.0"
 sp1-cc-client-executor = { git = "https://github.com/succinctlabs/sp1-contract-call.git", tag = "reth-1.9.3-sp1-6.1.0" }
 sp1-cc-host-executor = { git = "https://github.com/succinctlabs/sp1-contract-call.git", tag = "reth-1.9.3-sp1-6.1.0" }

--- a/canoe/sp1-cc/host/Cargo.toml
+++ b/canoe/sp1-cc/host/Cargo.toml
@@ -4,20 +4,20 @@ name = "canoe-sp1-cc-host"
 edition = "2021"
 
 [dependencies]
-rsp-primitives.workspace = true
 sp1-cc-client-executor.workspace = true
 sp1-cc-host-executor.workspace = true
 
+alloy-genesis.workspace = true
 alloy-primitives.workspace = true
-alloy-sol-types.workspace = true
-bincode.workspace = true
-
 alloy-rpc-client.workspace = true
 alloy-rpc-types.workspace = true
+alloy-sol-types.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
+bincode.workspace = true
 canoe-bindings.workspace = true
 canoe-provider.workspace = true
+serde_json.workspace = true
 
 # misc:
 tracing.workspace = true

--- a/canoe/sp1-cc/host/src/lib.rs
+++ b/canoe/sp1-cc/host/src/lib.rs
@@ -6,7 +6,6 @@ use anyhow::Result;
 use async_trait::async_trait;
 use canoe_bindings::{Journal, StatusCode};
 use canoe_provider::{CanoeInput, CanoeProvider, CertVerifierCall};
-use rsp_primitives::genesis::genesis_from_json;
 use sp1_cc_client_executor::ContractInput;
 use sp1_cc_host_executor::{EvmSketch, Genesis};
 use sp1_hypercube::{SP1PcsProofInner, SP1RecursionProof};
@@ -120,12 +119,12 @@ pub async fn canoe_proof_stdin(
     let genesis = if let Ok(genesis) = Genesis::try_from(l1_chain_id) {
         genesis
     } else {
-        let chain_config = match l1_chain_id {
-            17000 => genesis_from_json(HOLESKY_GENESIS).expect("genesis from json"),
-            3151908 => genesis_from_json(KURTOSIS_DEVNET_GENESIS).expect("genesis from json"),
+        let chain_genesis: alloy_genesis::Genesis = match l1_chain_id {
+            17000 => serde_json::from_str(HOLESKY_GENESIS).expect("genesis from json"),
+            3151908 => serde_json::from_str(KURTOSIS_DEVNET_GENESIS).expect("genesis from json"),
             _ => panic!("chain id {l1_chain_id} is not supported by canoe sp1 cc"),
         };
-        Genesis::Custom(chain_config.config)
+        Genesis::Custom(chain_genesis.config)
     };
 
     let sketch = EvmSketch::builder()

--- a/canoe/sp1-cc/verifier/Cargo.toml
+++ b/canoe/sp1-cc/verifier/Cargo.toml
@@ -10,7 +10,6 @@ eigenda-cert.workspace = true
 canoe-verifier = { workspace = true }
 canoe-bindings = { workspace = true }
 sp1-cc-client-executor = { workspace = true }
-rsp-primitives =  { workspace = true }
 
 cfg-if.workspace = true
 tracing.workspace = true

--- a/canoe/sp1-cc/verifier/src/lib.rs
+++ b/canoe/sp1-cc/verifier/src/lib.rs
@@ -11,8 +11,7 @@ use alloy_sol_types::SolValue;
 use canoe_bindings::Journal;
 use canoe_verifier::{chain_spec, CanoeVerifier, CertValidity, HokuleaCanoeVerificationError};
 use eigenda_cert::AltDACommitment;
-use rsp_primitives::genesis::Genesis;
-use sp1_cc_client_executor::ChainConfig;
+use sp1_cc_client_executor::{ChainConfig, Genesis};
 
 use tracing::info;
 

--- a/crates/compute-proof/src/kzg_proof.rs
+++ b/crates/compute-proof/src/kzg_proof.rs
@@ -38,12 +38,11 @@ pub fn compute_kzg_proof_with_srs<'s>(
 
     let commit_start = Instant::now();
     let commitment = kzg.commit_eval_form(&input_poly, srs)?;
-
     debug!(
         target: "compute_kzg_proof_with_srs",
-        "blob size {:?} bytes. Commit in eval form takes {:?}",
-        encoded_payload.len(),
-        commit_start.elapsed(),
+        blob_size_bytes = encoded_payload.len(),
+        elapsed = ?commit_start.elapsed(),
+        "Commit in eval form"
     );
 
     let proof_start = Instant::now();
@@ -51,9 +50,9 @@ pub fn compute_kzg_proof_with_srs<'s>(
 
     debug!(
         target: "compute_kzg_proof_with_srs",
-        "blob size {:?} bytes. Proof generations takes {:?}",
-        encoded_payload.len(),
-        proof_start.elapsed(),
+        blob_size_bytes = encoded_payload.len(),
+        elapsed = ?proof_start.elapsed(),
+        "Proof generation"
     );
 
     let proof_x_bigint: BigUint = proof.x.into();

--- a/crates/compute-proof/src/kzg_proof.rs
+++ b/crates/compute-proof/src/kzg_proof.rs
@@ -8,6 +8,8 @@ use rust_kzg_bn254_primitives::blob::Blob;
 use rust_kzg_bn254_primitives::errors::KzgError;
 use rust_kzg_bn254_prover::kzg::KZG;
 use rust_kzg_bn254_prover::srs::SRS;
+use std::time::Instant;
+use tracing::debug;
 
 include!(concat!(env!("OUT_DIR"), "/constants.rs"));
 
@@ -26,6 +28,7 @@ pub fn compute_kzg_proof_with_srs<'s>(
     srs: &SRS<'s>,
 ) -> Result<Bytes, KzgError> {
     let mut kzg = KZG::new();
+
     kzg.calculate_and_store_roots_of_unity(encoded_payload.len() as u64)
         .unwrap();
 
@@ -33,9 +36,24 @@ pub fn compute_kzg_proof_with_srs<'s>(
     let blob = Blob::new(encoded_payload).expect("should be able to construct a blob");
     let input_poly = blob.to_polynomial_eval_form()?;
 
+    let commit_start = Instant::now();
     let commitment = kzg.commit_eval_form(&input_poly, srs)?;
 
+    debug!(
+        target: "compute_kzg_proof_with_srs",
+        "commit in eval form takes {:?}",
+        commit_start.elapsed(),
+    );
+
+    let proof_start = Instant::now();
     let proof = kzg.compute_blob_proof(&blob, &commitment, srs)?;
+
+    debug!(
+        target: "compute_kzg_proof_with_srs",
+        "proof generations takes {:?}",
+        proof_start.elapsed(),
+    );
+
     let proof_x_bigint: BigUint = proof.x.into();
     let proof_y_bigint: BigUint = proof.y.into();
 

--- a/crates/compute-proof/src/kzg_proof.rs
+++ b/crates/compute-proof/src/kzg_proof.rs
@@ -41,7 +41,8 @@ pub fn compute_kzg_proof_with_srs<'s>(
 
     debug!(
         target: "compute_kzg_proof_with_srs",
-        "commit in eval form takes {:?}",
+        "blob size {:?} bytes. Commit in eval form takes {:?}",
+        encoded_payload.len(),
         commit_start.elapsed(),
     );
 
@@ -50,7 +51,8 @@ pub fn compute_kzg_proof_with_srs<'s>(
 
     debug!(
         target: "compute_kzg_proof_with_srs",
-        "proof generations takes {:?}",
+        "blob size {:?} bytes. Proof generations takes {:?}",
+        encoded_payload.len(),
         proof_start.elapsed(),
     );
 

--- a/crates/proof/src/eigenda_witness.rs
+++ b/crates/proof/src/eigenda_witness.rs
@@ -79,9 +79,28 @@ pub struct EigenDAWitness {
 }
 
 impl EigenDAWitness {
-    /// convert [EigenDAPreimage] into witnes data. It enforces there must be a canoe proof
-    /// if there is at least one required validity proof, and the number of KZG proof must
-    /// match number of encoded payload.
+    /// Constructs an [EigenDAWitness] from a preimage without validation. Use [Self::from_preimage]
+    /// if the inputs have not been prechecked.
+    pub fn from_preimage_unchecked(
+        preimage: EigenDAPreimage,
+        kzg_proofs: Vec<FixedBytes<64>>,
+        canoe_proof_bytes: Option<Vec<u8>>,
+    ) -> EigenDAWitness {
+        EigenDAWitness {
+            validities: preimage.validities,
+            encoded_payloads: preimage
+                .encoded_payloads
+                .into_iter()
+                .zip(kzg_proofs)
+                .map(|((commitment, payload), proof)| (commitment, payload, proof))
+                .collect(),
+            canoe_proof_bytes,
+        }
+    }
+
+    /// Constructs an [EigenDAWitness] from a preimage, validating that a canoe proof is present
+    /// when there is at least one validity entry, and that the number of KZG proofs matches the
+    /// number of encoded payloads.
     pub fn from_preimage(
         preimage: EigenDAPreimage,
         kzg_proofs: Vec<FixedBytes<64>>,
@@ -90,26 +109,14 @@ impl EigenDAWitness {
         if (!preimage.validities.is_empty()) && canoe_proof.is_none() {
             return Err(EigenDAWitnessError::MissingCanoeProof);
         }
-        let mut encoded_payloads_with_kzg_proof = Vec::new();
-
         if kzg_proofs.len() != preimage.encoded_payloads.len() {
             return Err(EigenDAWitnessError::MismatchKzgProof);
         }
-
-        for (i, proof) in kzg_proofs.iter().enumerate() {
-            encoded_payloads_with_kzg_proof.push((
-                preimage.encoded_payloads[i].0.clone(),
-                preimage.encoded_payloads[i].1.clone(),
-                *proof,
-            ))
-        }
-
-        let witness = EigenDAWitness {
-            validities: preimage.validities,
-            encoded_payloads: encoded_payloads_with_kzg_proof,
-            canoe_proof_bytes: canoe_proof,
-        };
-        Ok(witness)
+        Ok(Self::from_preimage_unchecked(
+            preimage,
+            kzg_proofs,
+            canoe_proof,
+        ))
     }
 
     /// Deconstruct [EigenDAWitness] back into its component parts: preimage, KZG proofs, and canoe proof.

--- a/crates/witgen/src/canoe_witness_provider.rs
+++ b/crates/witgen/src/canoe_witness_provider.rs
@@ -9,7 +9,7 @@ use kona_preimage::{PreimageKey, PreimageOracleClient};
 use kona_proof::BootInfo;
 use tracing::info;
 
-pub fn from_eigenda_preimage_to_canoe_inputs<A>(
+fn from_eigenda_preimage_to_canoe_inputs<A>(
     validities: &[(AltDACommitment, bool)],
     canoe_address_fetcher: A,
     l1_chain_id: ChainId,

--- a/crates/witgen/src/canoe_witness_provider.rs
+++ b/crates/witgen/src/canoe_witness_provider.rs
@@ -3,13 +3,14 @@ use alloy_primitives::{BlockNumber, ChainId, B256};
 use alloy_rlp::Decodable;
 use canoe_provider::{CanoeInput, CanoeProvider};
 use canoe_verifier_address_fetcher::CanoeVerifierAddressFetcher;
+use eigenda_cert::AltDACommitment;
 use hokulea_proof::eigenda_witness::EigenDAPreimage;
 use kona_preimage::{PreimageKey, PreimageOracleClient};
 use kona_proof::BootInfo;
 use tracing::info;
 
 pub fn from_eigenda_preimage_to_canoe_inputs<A>(
-    eigenda_preimage: &EigenDAPreimage,
+    validities: &[(AltDACommitment, bool)],
     canoe_address_fetcher: A,
     l1_chain_id: ChainId,
     l1_head_block_hash: B256,
@@ -20,7 +21,7 @@ where
 {
     let mut canoe_inputs = vec![];
 
-    for (altda_commitment, claimed_validity) in &eigenda_preimage.validities {
+    for (altda_commitment, claimed_validity) in validities {
         let canoe_input = CanoeInput {
             altda_commitment: altda_commitment.clone(),
             claimed_validity: *claimed_validity,
@@ -61,7 +62,7 @@ where
     let l1_chain_id = boot_info.rollup_config.l1_chain_id;
 
     let canoe_inputs = from_eigenda_preimage_to_canoe_inputs(
-        eigenda_preimage,
+        &eigenda_preimage.validities,
         canoe_address_fetcher,
         l1_chain_id,
         boot_info.l1_head,

--- a/crates/witgen/src/canoe_witness_provider.rs
+++ b/crates/witgen/src/canoe_witness_provider.rs
@@ -9,7 +9,7 @@ use kona_preimage::{PreimageKey, PreimageOracleClient};
 use kona_proof::BootInfo;
 use tracing::info;
 
-fn from_eigenda_preimage_to_canoe_inputs<A>(
+pub fn from_eigenda_preimage_to_canoe_inputs<A>(
     validities: &[(AltDACommitment, bool)],
     canoe_address_fetcher: A,
     l1_chain_id: ChainId,

--- a/crates/witgen/src/lib.rs
+++ b/crates/witgen/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod canoe_witness_provider;
 pub mod witness_provider;
-pub use canoe_witness_provider::from_boot_info_to_canoe_proof;
+pub use canoe_witness_provider::{
+    from_boot_info_to_canoe_proof, from_eigenda_preimage_to_canoe_inputs,
+};

--- a/crates/witgen/src/lib.rs
+++ b/crates/witgen/src/lib.rs
@@ -1,5 +1,3 @@
 pub mod canoe_witness_provider;
 pub mod witness_provider;
-pub use canoe_witness_provider::{
-    from_boot_info_to_canoe_proof, from_eigenda_preimage_to_canoe_inputs,
-};
+pub use canoe_witness_provider::from_boot_info_to_canoe_proof;


### PR DESCRIPTION
  Summary

 1. EigenDAWitness::from_preimage_unchecked (ffb8271)
  - New constructor on the witness type that builds it directly from a preimage without re-validating. Touches crates/proof/src/eigenda_witness.rs and the witgen call sites (canoe_witness_provider.rs,
  witgen/src/lib.rs).

  2. Narrow from_eigenda_preimage_to_canoe_inputs signature (7fc4f04, 8d71b10)
  - Function now takes validities directly instead of deriving them, simplifying the caller contract.

  3. Drop rsp-primitives from canoe-sp1-cc (2e4b193, caf7fef, a5745a1)
  - Inlined genesis_from_json into canoe/sp1-cc/host/src/lib.rs so the host and verifier no longer depend on rsp-primitives. Removed from both crate Cargo.tomls and the workspace root.

  4. Debug instrumentation (c3b2cb2, 1d34001, 0b15739)
  - Added blob-size logging at proof generation in crates/compute-proof/src/kzg_proof.rs