### PR TITLE
chore: Bump kona to v1.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,30 +76,30 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07dc44b606f29348ce7c127e7f872a6d2df3cfeff85b7d6bba62faca75112fdd"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 1.6.3",
  "alloy-contract",
  "alloy-core",
- "alloy-eips",
- "alloy-genesis",
- "alloy-network",
- "alloy-provider",
- "alloy-rpc-client",
- "alloy-rpc-types",
- "alloy-serde",
- "alloy-signer",
+ "alloy-eips 1.6.3",
+ "alloy-genesis 1.6.3",
+ "alloy-network 1.6.3",
+ "alloy-provider 1.6.3",
+ "alloy-rpc-client 1.6.3",
+ "alloy-rpc-types 1.6.3",
+ "alloy-serde 1.6.3",
+ "alloy-signer 1.6.3",
  "alloy-signer-local",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-transport 1.6.3",
+ "alloy-transport-http 1.6.3",
  "alloy-trie 0.9.4",
 ]
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.30"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f374d3c6d729268bbe2d0e0ff992bb97898b2df756691a62ee1d5f0506bc39"
+checksum = "84e0378e959aa6a885897522080a990e80eb317f1e9a222a604492ea50e13096"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "num_enum 0.7.5",
  "serde",
@@ -112,12 +112,39 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e4ff99651d46cef43767b5e8262ea228cd05287409ccb0c947cc25e70a952f9"
 dependencies = [
- "alloy-eips",
- "alloy-primitives 1.5.6",
+ "alloy-eips 1.6.3",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 1.6.3",
  "alloy-trie 0.9.4",
- "alloy-tx-macros",
+ "alloy-tx-macros 1.6.3",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more 2.1.1",
+ "either",
+ "k256 0.13.4",
+ "once_cell",
+ "rand 0.8.5",
+ "secp256k1 0.30.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-consensus"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d64da86c616b5092ea64eea648f311bbd58630a0b384c42d699175d6f9122b"
+dependencies = [
+ "alloy-eips 2.0.5",
+ "alloy-primitives 1.6.0",
+ "alloy-rlp",
+ "alloy-serde 2.0.5",
+ "alloy-trie 0.9.4",
+ "alloy-tx-macros 2.0.5",
  "auto_impl",
  "borsh",
  "c-kzg",
@@ -139,11 +166,25 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a0701b0eda8051a2398591113e7862f807ccdd3315d0b441f06c2a0865a379b"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives 1.5.6",
+ "alloy-consensus 1.6.3",
+ "alloy-eips 1.6.3",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 1.6.3",
+ "serde",
+]
+
+[[package]]
+name = "alloy-consensus-any"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd98696ca3617d3a9ba1a6f2011880cbfd5618228dab6400c9f8bca457859a8"
+dependencies = [
+ "alloy-consensus 2.0.4",
+ "alloy-eips 2.0.5",
+ "alloy-primitives 1.6.0",
+ "alloy-rlp",
+ "alloy-serde 2.0.5",
  "serde",
 ]
 
@@ -153,16 +194,16 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3c83c7a3c4e1151e8cac383d0a67ddf358f37e5ea51c95a1283d897c9de0a5a"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 1.6.3",
  "alloy-dyn-abi",
  "alloy-json-abi",
- "alloy-network",
- "alloy-network-primitives",
- "alloy-primitives 1.5.6",
- "alloy-provider",
- "alloy-rpc-types-eth",
+ "alloy-network 1.6.3",
+ "alloy-network-primitives 1.6.3",
+ "alloy-primitives 1.6.0",
+ "alloy-provider 1.6.3",
+ "alloy-rpc-types-eth 1.6.3",
  "alloy-sol-types",
- "alloy-transport",
+ "alloy-transport 1.6.3",
  "futures",
  "futures-util",
  "serde_json",
@@ -171,31 +212,31 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bad0f48b9fe97029db0de15bb29a75f5f84848530673ba271b78216947d3877"
+checksum = "62ddde5968de6044d67af107ad835bc0069a7ca245870b94c5958a7d8712b184"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "alloy-sol-types",
 ]
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ab1b2f1b48a7e6b3597cb2afae04f93879fb69d71e39736b5663d7366b23f2"
+checksum = "a475bb02d9cef2dbb99065c1664ab3fe1f9352e21d6d5ed3f02cdbfc06ed1abc"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "alloy-sol-type-parser",
  "alloy-sol-types",
  "itoa",
  "serde",
  "serde_json",
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -204,7 +245,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "crc",
  "serde",
@@ -217,7 +258,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9441120fa82df73e8959ae0e4ab8ade03de2aaae61be313fbf5746277847ce25"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "borsh",
  "serde",
@@ -229,7 +270,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2919c5a56a1007492da313e7a3b6d45ef5edc5d33416fdec63c0d7a2702a0d20"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "borsh",
  "k256 0.13.4",
@@ -244,7 +285,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3231de68d5d6e75332b7489cfcc7f4dfabeba94d990a10e4b923af0e6623540"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "borsh",
  "serde",
@@ -260,20 +301,45 @@ dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
  "alloy-eip7928",
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 1.6.3",
  "auto_impl",
  "borsh",
  "c-kzg",
  "derive_more 2.1.1",
  "either",
- "ethereum_ssz",
- "ethereum_ssz_derive",
+ "ethereum_ssz 0.9.1",
+ "ethereum_ssz_derive 0.9.1",
  "serde",
  "serde_with",
  "sha2 0.10.9",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dca4c89ace90684b4b77366d00631ed498c9af962079af2a5dbc593a0618a77"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-eip7928",
+ "alloy-primitives 1.6.0",
+ "alloy-rlp",
+ "alloy-serde 2.0.5",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more 2.1.1",
+ "either",
+ "ethereum_ssz 0.10.4",
+ "ethereum_ssz_derive 0.10.4",
+ "serde",
+ "serde_with",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -282,11 +348,11 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dbe7c66c859b658d879b22e8aaa19546dab726b0639f4649a424ada3d99349e"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 1.6.3",
+ "alloy-eips 1.6.3",
  "alloy-hardforks 0.3.5",
- "alloy-primitives 1.5.6",
- "alloy-rpc-types-eth",
+ "alloy-primitives 1.6.0",
+ "alloy-rpc-types-eth 1.6.3",
  "alloy-sol-types",
  "auto_impl",
  "derive_more 2.1.1",
@@ -302,12 +368,12 @@ version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527b47dc39850c6168002ddc1f7a2063e15d26137c1bb5330f6065a7524c1aa9"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 1.6.3",
+ "alloy-eips 1.6.3",
  "alloy-hardforks 0.4.7",
- "alloy-primitives 1.5.6",
- "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
+ "alloy-primitives 1.6.0",
+ "alloy-rpc-types-engine 1.6.3",
+ "alloy-rpc-types-eth 1.6.3",
  "alloy-sol-types",
  "auto_impl",
  "derive_more 2.1.1",
@@ -320,24 +386,22 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.27.3"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b991c370ce44e70a3a9e474087e3d65e42e66f967644ad729dc4cec09a21fd09"
+checksum = "c1ceeea6dcbbcd4e546b27700763a6f6c3b3fee30054209884f521078b6fda4f"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.4",
+ "alloy-eips 2.0.5",
  "alloy-hardforks 0.4.7",
- "alloy-op-hardforks",
- "alloy-primitives 1.5.6",
- "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
+ "alloy-primitives 1.6.0",
+ "alloy-rpc-types-engine 2.0.4",
+ "alloy-rpc-types-eth 2.0.4",
  "alloy-sol-types",
  "auto_impl",
  "derive_more 2.1.1",
- "op-alloy",
- "op-revm 15.0.0",
- "revm 34.0.0",
+ "revm 38.0.0",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -346,9 +410,24 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55d9d1aba3f914f0e8db9e4616ae37f3d811426d95bdccf44e47d0605ab202f6"
 dependencies = [
- "alloy-eips",
- "alloy-primitives 1.5.6",
- "alloy-serde",
+ "alloy-eips 1.6.3",
+ "alloy-primitives 1.6.0",
+ "alloy-serde 1.6.3",
+ "alloy-trie 0.9.4",
+ "borsh",
+ "serde",
+ "serde_with",
+]
+
+[[package]]
+name = "alloy-genesis"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a71ff8b55d2b8aa05259f474cae7dea0e4991724dc18936b81cb23ec492a0c2a"
+dependencies = [
+ "alloy-eips 2.0.5",
+ "alloy-primitives 1.6.0",
+ "alloy-serde 2.0.5",
  "alloy-trie 0.9.4",
  "borsh",
  "serde",
@@ -363,7 +442,7 @@ checksum = "889eb3949b58368a09d4f16931c660275ef5fb08e5fbd4a96573b19c7085c41f"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "auto_impl",
  "dyn-clone",
 ]
@@ -376,7 +455,7 @@ checksum = "83ba208044232d14d4adbfa77e57d6329f51bc1acc21f5667bb7db72d88a0831"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "auto_impl",
  "dyn-clone",
  "serde",
@@ -384,11 +463,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e414aa37b335ad2acb78a95814c59d137d53139b412f87aed1e10e2d862cd49"
+checksum = "7c36c9d7f9021601b04bfef14a4b64849f6d73116a4e91e071d7fbfe10247901"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "alloy-sol-type-parser",
  "serde",
  "serde_json",
@@ -400,7 +479,22 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57586581f2008933241d16c3e3f633168b3a5d2738c5c42ea5246ec5e0ef17a"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
+ "alloy-sol-types",
+ "http 1.4.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-json-rpc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0a82e56b1843bce483942d54fcadea92e676f1bde162e93c7d3b621fabc4e1"
+dependencies = [
+ "alloy-primitives 1.6.0",
  "alloy-sol-types",
  "http 1.4.0",
  "serde",
@@ -415,16 +509,42 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b36c2a0ed74e48851f78415ca5b465211bd678891ba11e88fee09eac534bab1"
 dependencies = [
- "alloy-consensus",
- "alloy-consensus-any",
- "alloy-eips",
- "alloy-json-rpc",
- "alloy-network-primitives",
- "alloy-primitives 1.5.6",
- "alloy-rpc-types-any",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "alloy-signer",
+ "alloy-consensus 1.6.3",
+ "alloy-consensus-any 1.6.3",
+ "alloy-eips 1.6.3",
+ "alloy-json-rpc 1.6.3",
+ "alloy-network-primitives 1.6.3",
+ "alloy-primitives 1.6.0",
+ "alloy-rpc-types-any 1.6.3",
+ "alloy-rpc-types-eth 1.6.3",
+ "alloy-serde 1.6.3",
+ "alloy-signer 1.6.3",
+ "alloy-sol-types",
+ "async-trait",
+ "auto_impl",
+ "derive_more 2.1.1",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-network"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed08ae169869e08370ed121612e0d3dadac33d1a256e9f2465926b23f0bd7d95"
+dependencies = [
+ "alloy-consensus 2.0.4",
+ "alloy-consensus-any 2.0.4",
+ "alloy-eips 2.0.5",
+ "alloy-json-rpc 2.0.5",
+ "alloy-network-primitives 2.0.4",
+ "alloy-primitives 1.6.0",
+ "alloy-rpc-types-any 2.0.4",
+ "alloy-rpc-types-eth 2.0.4",
+ "alloy-serde 2.0.5",
+ "alloy-signer 2.0.5",
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
@@ -441,38 +561,51 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "636c8051da58802e757b76c3b65af610b95799f72423dc955737dec73de234fd"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives 1.5.6",
- "alloy-serde",
+ "alloy-consensus 1.6.3",
+ "alloy-eips 1.6.3",
+ "alloy-primitives 1.6.0",
+ "alloy-serde 1.6.3",
+ "serde",
+]
+
+[[package]]
+name = "alloy-network-primitives"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e6c7ad28afe348a9a9c5624b67ee5b3607b8de98d5816b3056ecdfa6fa2697"
+dependencies = [
+ "alloy-consensus 2.0.4",
+ "alloy-eips 2.0.5",
+ "alloy-primitives 1.6.0",
+ "alloy-serde 2.0.5",
  "serde",
 ]
 
 [[package]]
 name = "alloy-op-evm"
-version = "0.26.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.14#3fd820798c94692dd97a3a48aa154c63bcbee45d"
+version = "0.32.0"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-evm 0.27.3",
+ "alloy-consensus 2.0.4",
+ "alloy-eips 2.0.5",
+ "alloy-evm 0.34.0",
  "alloy-op-hardforks",
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "auto_impl",
  "op-alloy",
- "op-revm 15.0.0",
- "revm 34.0.0",
+ "op-revm 20.0.0",
+ "revm 38.0.0",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "alloy-op-hardforks"
-version = "0.4.7"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.14#3fd820798c94692dd97a3a48aa154c63bcbee45d"
+version = "0.5.0"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "alloy-chains",
  "alloy-hardforks 0.4.7",
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "auto_impl",
  "serde",
 ]
@@ -501,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b1483f8c2562bf35f0270b697d5b5fe8170464e935bd855a4c5eaf6f89b354"
+checksum = "4885c1409b6936c4898e646ef58baf6ec54edaf6d8179f79df805a7b85b7cf3e"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -511,7 +644,7 @@ dependencies = [
  "const-hex",
  "derive_more 2.1.1",
  "foldhash 0.2.0",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap 2.13.0",
  "itoa",
  "k256 0.13.4",
@@ -523,8 +656,9 @@ dependencies = [
  "rkyv",
  "ruint",
  "rustc-hash",
+ "secp256k1 0.31.1",
  "serde",
- "sha3",
+ "sha3 0.11.0",
 ]
 
 [[package]]
@@ -534,21 +668,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3dd56e2eafe8b1803e325867ac2c8a4c73c9fb5f341ffd8347f9344458c5922"
 dependencies = [
  "alloy-chains",
- "alloy-consensus",
- "alloy-eips",
- "alloy-json-rpc",
- "alloy-network",
- "alloy-network-primitives",
- "alloy-primitives 1.5.6",
- "alloy-pubsub",
- "alloy-rpc-client",
- "alloy-rpc-types-debug",
- "alloy-rpc-types-eth",
- "alloy-rpc-types-trace",
- "alloy-signer",
+ "alloy-consensus 1.6.3",
+ "alloy-eips 1.6.3",
+ "alloy-json-rpc 1.6.3",
+ "alloy-network 1.6.3",
+ "alloy-network-primitives 1.6.3",
+ "alloy-primitives 1.6.0",
+ "alloy-rpc-client 1.6.3",
+ "alloy-rpc-types-debug 1.6.3",
+ "alloy-rpc-types-eth 1.6.3",
+ "alloy-rpc-types-trace 1.6.3",
+ "alloy-signer 1.6.3",
  "alloy-sol-types",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-transport 1.6.3",
+ "alloy-transport-http 1.6.3",
+ "async-stream",
+ "async-trait",
+ "auto_impl",
+ "dashmap",
+ "either",
+ "futures",
+ "futures-utils-wasm",
+ "lru 0.16.3",
+ "parking_lot",
+ "pin-project",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-provider"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93a7c17472b55482d4734154c2f5ed13f72e03f6752cebb927f6a2d8b52e646c"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus 2.0.4",
+ "alloy-eips 2.0.5",
+ "alloy-json-rpc 2.0.5",
+ "alloy-network 2.0.4",
+ "alloy-network-primitives 2.0.4",
+ "alloy-primitives 1.6.0",
+ "alloy-pubsub",
+ "alloy-rpc-client 2.0.4",
+ "alloy-rpc-types-debug 2.0.5",
+ "alloy-rpc-types-eth 2.0.4",
+ "alloy-rpc-types-trace 2.0.4",
+ "alloy-signer 2.0.5",
+ "alloy-sol-types",
+ "alloy-transport 2.0.5",
+ "alloy-transport-http 2.0.4",
  "alloy-transport-ipc",
  "alloy-transport-ws",
  "async-stream",
@@ -561,7 +736,7 @@ dependencies = [
  "lru 0.16.3",
  "parking_lot",
  "pin-project",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -573,13 +748,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eebf54983d4fccea08053c218ee5c288adf2e660095a243d0532a8070b43955"
+checksum = "7cd85cfea1fa8ebd20d3475e961fe3a3624c0eb4659ea137715c0c83c8aeaff0"
 dependencies = [
- "alloy-json-rpc",
- "alloy-primitives 1.5.6",
- "alloy-transport",
+ "alloy-json-rpc 2.0.5",
+ "alloy-primitives 1.6.0",
+ "alloy-transport 2.0.5",
  "auto_impl",
  "bimap",
  "futures",
@@ -621,16 +796,39 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91577235d341a1bdbee30a463655d08504408a4d51e9f72edbfc5a622829f402"
 dependencies = [
- "alloy-json-rpc",
- "alloy-primitives 1.5.6",
+ "alloy-json-rpc 1.6.3",
+ "alloy-primitives 1.6.0",
+ "alloy-transport 1.6.3",
+ "alloy-transport-http 1.6.3",
+ "futures",
+ "pin-project",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.3",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-rpc-client"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5beb5c2fe6b960c8e8b038e69fd502a90a2e930afa4770efb748b163b0767729"
+dependencies = [
+ "alloy-json-rpc 2.0.5",
+ "alloy-primitives 1.6.0",
  "alloy-pubsub",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-transport 2.0.5",
+ "alloy-transport-http 2.0.4",
  "alloy-transport-ipc",
  "alloy-transport-ws",
  "futures",
  "pin-project",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "tokio",
@@ -647,11 +845,23 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cff039bf01a17d76c0aace3a3a773d5f895eb4c68baaae729ec9da9e86c99c"
 dependencies = [
- "alloy-primitives 1.5.6",
- "alloy-rpc-types-debug",
- "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-primitives 1.6.0",
+ "alloy-rpc-types-engine 1.6.3",
+ "alloy-rpc-types-eth 1.6.3",
+ "alloy-serde 1.6.3",
+ "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee1257a278f6d293e05c5162c5940a1561b1aa85ded0028b464c81de37ebfa5"
+dependencies = [
+ "alloy-primitives 1.6.0",
+ "alloy-rpc-types-debug 2.0.5",
+ "alloy-rpc-types-eth 2.0.4",
+ "alloy-serde 2.0.5",
  "serde",
 ]
 
@@ -661,20 +871,35 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73234a141ecce14e2989748c04fcac23deee67a445e2c4c167cfb42d4dacd1b6"
 dependencies = [
- "alloy-consensus-any",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-consensus-any 1.6.3",
+ "alloy-rpc-types-eth 1.6.3",
+ "alloy-serde 1.6.3",
+]
+
+[[package]]
+name = "alloy-rpc-types-any"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a234bfbdf7a76c3d13808f729af5321852de3dedcaa6fc6d5f54787aaf54c6a"
+dependencies = [
+ "alloy-consensus-any 2.0.4",
+ "alloy-network-primitives 2.0.4",
+ "alloy-primitives 1.6.0",
+ "alloy-rpc-types-eth 2.0.4",
+ "alloy-serde 2.0.5",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.6.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625af0c3ebd3c31322edb1fb6b8e3e518acc39e164ed07e422eaff05310ff2fa"
+checksum = "296450f5e76bece0116c939b9437b0421a5da9c5d40031bf4cf9b38d3d94e475"
 dependencies = [
- "alloy-eips",
- "alloy-primitives 1.5.6",
- "alloy-rpc-types-engine",
+ "alloy-eips 2.0.5",
+ "alloy-primitives 1.6.0",
+ "alloy-rpc-types-engine 2.0.4",
  "derive_more 2.1.1",
  "serde",
  "serde_json",
@@ -688,7 +913,20 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "779f70ab16a77e305571881b07a9bc6b0068ae6f962497baf5762825c5b839fb"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
+ "derive_more 2.1.1",
+ "serde",
+ "serde_with",
+]
+
+[[package]]
+name = "alloy-rpc-types-debug"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48b9ad6eee93dd35a9ec0a6c1c6b180892a900ee17a6ed6500921552dd71e846"
+dependencies = [
+ "alloy-primitives 1.6.0",
+ "alloy-rlp",
  "derive_more 2.1.1",
  "serde",
  "serde_with",
@@ -700,15 +938,35 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10620d600cc46538f613c561ac9a923843c6c74c61f054828dcdb8dd18c72ec4"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives 1.5.6",
+ "alloy-consensus 1.6.3",
+ "alloy-eips 1.6.3",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 1.6.3",
  "derive_more 2.1.1",
- "ethereum_ssz",
- "ethereum_ssz_derive",
- "jsonwebtoken",
+ "ethereum_ssz 0.9.1",
+ "ethereum_ssz_derive 0.9.1",
+ "jsonwebtoken 9.3.1",
+ "rand 0.8.5",
+ "serde",
+ "strum",
+]
+
+[[package]]
+name = "alloy-rpc-types-engine"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b12366c96f4013e1aeebc96c6b56e5f33f07853c42ea2f485045c0c157a4a1"
+dependencies = [
+ "alloy-consensus 2.0.4",
+ "alloy-eips 2.0.5",
+ "alloy-primitives 1.6.0",
+ "alloy-rlp",
+ "alloy-serde 2.0.5",
+ "derive_more 2.1.1",
+ "ethereum_ssz 0.10.4",
+ "ethereum_ssz_derive 0.10.4",
+ "jsonwebtoken 10.4.0",
  "rand 0.8.5",
  "serde",
  "strum",
@@ -720,13 +978,34 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "010e101dbebe0c678248907a2545b574a87d078d82c2f6f5d0e8e7c9a6149a10"
 dependencies = [
- "alloy-consensus",
- "alloy-consensus-any",
- "alloy-eips",
- "alloy-network-primitives",
- "alloy-primitives 1.5.6",
+ "alloy-consensus 1.6.3",
+ "alloy-consensus-any 1.6.3",
+ "alloy-eips 1.6.3",
+ "alloy-network-primitives 1.6.3",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 1.6.3",
+ "alloy-sol-types",
+ "itertools 0.14.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-rpc-types-eth"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56a282daf869eeb7383d3d5c2deb35b0b3fb45ecb329513af4090fc61245ee18"
+dependencies = [
+ "alloy-consensus 2.0.4",
+ "alloy-consensus-any 2.0.4",
+ "alloy-eips 2.0.5",
+ "alloy-network-primitives 2.0.4",
+ "alloy-primitives 1.6.0",
+ "alloy-rlp",
+ "alloy-serde 2.0.5",
  "alloy-sol-types",
  "itertools 0.14.0",
  "serde",
@@ -741,9 +1020,23 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be096f74d85e1f927580b398bf7bc5b4aa62326f149680ec0867e3c040c9aced"
 dependencies = [
- "alloy-primitives 1.5.6",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-primitives 1.6.0",
+ "alloy-rpc-types-eth 1.6.3",
+ "alloy-serde 1.6.3",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-rpc-types-trace"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184b5d14152b68b0bb8beb621339d94f0b761a37958bb365fbf7c00922125c2"
+dependencies = [
+ "alloy-primitives 1.6.0",
+ "alloy-rpc-types-eth 2.0.4",
+ "alloy-serde 2.0.5",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -755,7 +1048,18 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e6d631f8b975229361d8af7b2c749af31c73b3cf1352f90e144ddb06227105e"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc21a8772af7d78bba286726aa245bd2ff81cd9abe230afea2e91578996831c9"
+dependencies = [
+ "alloy-primitives 1.6.0",
  "serde",
  "serde_json",
 ]
@@ -766,7 +1070,22 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97f40010b5e8f79b70bf163b38cd15f529b18ca88c4427c0e43441ee54e4ed82"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
+ "async-trait",
+ "auto_impl",
+ "either",
+ "elliptic-curve 0.13.8",
+ "k256 0.13.4",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-signer"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ffbce94c50dd9d4d1f83e044c5595bbd3ada981bd3057ce28b3a5470e77385d"
+dependencies = [
+ "alloy-primitives 1.6.0",
  "async-trait",
  "auto_impl",
  "either",
@@ -781,10 +1100,10 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8857c6346edb898df606130a7d29b3dfc765746ccc7915b36466a1e16347b93"
 dependencies = [
- "alloy-consensus",
- "alloy-network",
- "alloy-primitives 1.5.6",
- "alloy-signer",
+ "alloy-consensus 1.6.3",
+ "alloy-network 1.6.3",
+ "alloy-primitives 1.6.0",
+ "alloy-signer 1.6.3",
  "async-trait",
  "aws-config",
  "aws-sdk-kms",
@@ -800,10 +1119,10 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c4ec1cc27473819399a3f0da83bc1cef0ceaac8c1c93997696e46dc74377a58"
 dependencies = [
- "alloy-consensus",
- "alloy-network",
- "alloy-primitives 1.5.6",
- "alloy-signer",
+ "alloy-consensus 1.6.3",
+ "alloy-network 1.6.3",
+ "alloy-primitives 1.6.0",
+ "alloy-signer 1.6.3",
  "async-trait",
  "k256 0.13.4",
  "rand 0.8.5",
@@ -812,9 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4b64c8146291f750c3f391dff2dd40cf896f7e2b253417a31e342aa7265baa"
+checksum = "840128ed2b2971d6d4668a553fe403a82683d3acc646c73e75887e7157408033"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -826,9 +1145,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9df903674682f9bae8d43fdea535ab48df2d6a8cb5104ca29c58ada22ef67b3"
+checksum = "63ec265e5d65d725175f6ca7711c970824c90ef9c0d1f1973711d4150ee612dd"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -838,16 +1157,16 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "sha3",
+ "sha3 0.11.0",
  "syn 2.0.115",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "737b8a959f527a86e07c44656db237024a32ae9b97d449f788262a547e8aa136"
+checksum = "89bf01077f18650876cfa682eb1f949967b5cde03f1a51c955c469d2c9b4aa67"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -863,22 +1182,22 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28e6e86c6d2db52654b65a5a76b4f57eae5a32a7f0aa2222d1dbdb74e2cb8e0"
+checksum = "857b470ecdd2ed38beaf82ad1a38c516a8ff75266750f38b9eeed001d575241b"
 dependencies = [
  "serde",
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf7effe4ab0a4f52c865959f790036e61a7983f68b13b75d7fbcedf20b753ce"
+checksum = "384cf252de0db2dec52821eac037a7f57e2aa33fe5b900ce6fe39973402341f1"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "alloy-sol-macro",
  "serde",
 ]
@@ -889,7 +1208,30 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a03bb3f02b9a7ab23dacd1822fa7f69aa5c8eefcdcf57fad085e0b8d76fb4334"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 1.6.3",
+ "auto_impl",
+ "base64 0.22.1",
+ "derive_more 2.1.1",
+ "futures",
+ "futures-utils-wasm",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower 0.5.3",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-transport"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86052fdcec72d37ca4aa4b66254601e7453c45a6e1c70aa4561033d002fb80cc"
+dependencies = [
+ "alloy-json-rpc 2.0.5",
  "auto_impl",
  "base64 0.22.1",
  "derive_more 2.1.1",
@@ -912,16 +1254,32 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ce599598ef8ebe067f3627509358d9faaa1ef94f77f834a7783cd44209ef55c"
 dependencies = [
- "alloy-json-rpc",
- "alloy-rpc-types-engine",
- "alloy-transport",
+ "alloy-json-rpc 1.6.3",
+ "alloy-transport 1.6.3",
+ "itertools 0.14.0",
+ "reqwest 0.12.28",
+ "serde_json",
+ "tower 0.5.3",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "alloy-transport-http"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed3ed3300a998f88639ed619fdbbd88bd82865e00c6a8ecb796c99eb12358f6"
+dependencies = [
+ "alloy-json-rpc 2.0.5",
+ "alloy-rpc-types-engine 2.0.4",
+ "alloy-transport 2.0.5",
  "http-body-util",
  "hyper 1.8.1",
  "hyper-tls",
  "hyper-util",
  "itertools 0.14.0",
- "jsonwebtoken",
- "reqwest",
+ "jsonwebtoken 10.4.0",
+ "reqwest 0.13.4",
  "serde_json",
  "tower 0.5.3",
  "tracing",
@@ -930,13 +1288,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49963a2561ebd439549915ea61efb70a7b13b97500ec16ca507721c9d9957d07"
+checksum = "bfb89df168b24773ef603af14f2449c05a7d3f27d05d3eceaea6bf96cccae168"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 2.0.5",
  "alloy-pubsub",
- "alloy-transport",
+ "alloy-transport 2.0.5",
  "bytes",
  "futures",
  "interprocess",
@@ -950,18 +1308,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed38ea573c6658e0c2745af9d1f1773b1ed83aa59fbd9c286358ad469c3233a"
+checksum = "33e32e0b47d3b3bf5770b7c132090c614b008d307c5e1544f1925f5b7e9e9af6"
 dependencies = [
  "alloy-pubsub",
- "alloy-transport",
+ "alloy-transport 2.0.5",
  "futures",
  "http 1.4.0",
+ "rustls 0.23.36",
  "serde_json",
  "tokio",
  "tokio-tungstenite",
  "tracing",
+ "url",
  "ws_stream_wasm",
 ]
 
@@ -971,7 +1331,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "983d99aa81f586cef9dae38443245e585840fcf0fc58b09aee0b1f27aed1d500"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "arrayvec",
  "derive_more 2.1.1",
@@ -987,7 +1347,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d7fd448ab0a017de542de1dcca7a58e7019fe0e7a34ed3f9543ebddf6aceffa"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "arrayvec",
  "derive_more 2.1.1",
@@ -1005,6 +1365,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "397406cf04b11ca2a48e6f81804c70af3f40a36abf648e11dc7416043eb0834d"
 dependencies = [
  "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "alloy-tx-macros"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01a0035943b75fe1e249f52e688492d7a1b1826bc2d19b8e1d5d3c24a2ad8f50"
+dependencies = [
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.115",
@@ -1076,7 +1448,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1087,7 +1459,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1630,6 +2002,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -2224,7 +2597,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -2249,6 +2622,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array 0.14.9",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -2284,7 +2666,7 @@ checksum = "a381a5f681e536070483826412fcfcd6f6637921717c6aa0a3759926899ee9c2"
 dependencies = [
  "duplicate",
  "maybe-async",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -2480,7 +2862,7 @@ dependencies = [
 name = "canoe-provider"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "alloy-sol-types",
  "anyhow",
  "async-trait",
@@ -2493,7 +2875,7 @@ dependencies = [
 name = "canoe-sp1-cc-client"
 version = "0.0.0"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "alloy-sol-types",
  "bincode",
  "canoe-bindings",
@@ -2506,10 +2888,10 @@ dependencies = [
 name = "canoe-sp1-cc-host"
 version = "0.1.0"
 dependencies = [
- "alloy-genesis",
- "alloy-primitives 1.5.6",
- "alloy-rpc-client",
- "alloy-rpc-types",
+ "alloy-genesis 1.6.3",
+ "alloy-primitives 1.6.0",
+ "alloy-rpc-client 1.6.3",
+ "alloy-rpc-types 1.6.3",
  "alloy-sol-types",
  "anyhow",
  "async-trait",
@@ -2529,7 +2911,7 @@ dependencies = [
 name = "canoe-sp1-cc-verifier"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "alloy-sol-types",
  "bincode",
  "canoe-bindings",
@@ -2546,7 +2928,7 @@ dependencies = [
 name = "canoe-sp1-cc-vkey-bin"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "clap",
  "sp1-sdk",
  "tokio",
@@ -2572,7 +2954,7 @@ dependencies = [
 name = "canoe-steel-methods"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "alloy-sol-types",
  "hex",
  "risc0-build",
@@ -2584,14 +2966,14 @@ dependencies = [
 name = "canoe-steel-verifier"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "bincode",
  "canoe-bindings",
  "canoe-steel-methods",
  "canoe-verifier",
  "cfg-if",
  "eigenda-cert",
- "revm-primitives 21.0.2",
+ "revm-primitives 23.0.0",
  "risc0-steel",
  "risc0-zkvm",
  "serde_json",
@@ -2602,8 +2984,8 @@ dependencies = [
 name = "canoe-verifier"
 version = "0.1.0"
 dependencies = [
- "alloy-genesis",
- "alloy-primitives 1.5.6",
+ "alloy-genesis 1.6.3",
+ "alloy-primitives 1.6.0",
  "eigenda-cert",
  "reth-chainspec",
  "reth-evm",
@@ -2617,7 +2999,7 @@ dependencies = [
 name = "canoe-verifier-address-fetcher"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "eigenda-cert",
  "thiserror 2.0.18",
 ]
@@ -2780,6 +3162,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2814,7 +3206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -2917,6 +3309,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -3063,6 +3464,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3080,6 +3490,16 @@ checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
  "darling_core 0.21.3",
  "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -3112,6 +3532,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "strsim",
+ "syn 2.0.115",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3129,6 +3563,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.115",
 ]
@@ -3409,8 +3854,18 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -3577,7 +4032,7 @@ dependencies = [
 name = "eigenda-cert"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "alloy-sol-types",
  "anyhow",
@@ -3698,7 +4153,7 @@ dependencies = [
  "rand 0.8.5",
  "rlp",
  "serde",
- "sha3",
+ "sha3 0.10.8",
  "zeroize",
 ]
 
@@ -3767,7 +4222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3824,7 +4279,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dc1355dbb41fbbd34ec28d4fb2a57d9a70c67ac3c19f6a5ca4d4a176b9e997a"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "hex",
  "serde",
  "serde_derive",
@@ -3837,9 +4292,24 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "ethereum_serde_utils",
  "itertools 0.13.0",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "typenum",
+]
+
+[[package]]
+name = "ethereum_ssz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e462875ad8693755ea8913d6e905715c76ea4836e2254e18c9cf0f7a8f8c2a13"
+dependencies = [
+ "alloy-primitives 1.6.0",
+ "ethereum_serde_utils",
+ "itertools 0.14.0",
  "serde",
  "serde_derive",
  "smallvec",
@@ -3853,6 +4323,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
 dependencies = [
  "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "ethereum_ssz_derive"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf022360bdbe9456eda5f35718a50476d5b2a0d51a97ed4eae27420737a6fba"
+dependencies = [
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.115",
@@ -4382,6 +4864,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
  "serde",
  "serde_core",
 ]
@@ -4450,19 +4941,20 @@ dependencies = [
 name = "hokulea-client"
 version = "0.1.0"
 dependencies = [
- "alloy-consensus",
- "alloy-evm 0.27.3",
+ "alloy-consensus 2.0.4",
+ "alloy-evm 0.34.0",
  "alloy-op-evm",
  "hokulea-eigenda",
  "kona-client",
  "kona-derive",
  "kona-driver",
  "kona-executor",
+ "kona-genesis",
  "kona-preimage",
  "kona-proof",
- "op-alloy-consensus 0.23.1",
- "op-revm 15.0.0",
- "revm 34.0.0",
+ "op-alloy-consensus 2.0.0",
+ "op-revm 20.0.0",
+ "revm 38.0.0",
  "tracing",
 ]
 
@@ -4470,26 +4962,27 @@ dependencies = [
 name = "hokulea-client-bin"
 version = "0.1.0"
 dependencies = [
- "alloy-evm 0.27.3",
+ "alloy-evm 0.34.0",
  "alloy-op-evm",
  "cfg-if",
  "hokulea-client",
  "hokulea-proof",
  "kona-client",
+ "kona-genesis",
  "kona-preimage",
  "kona-proof",
  "kona-std-fpvm",
  "kona-std-fpvm-proc",
- "op-alloy-consensus 0.23.1",
- "op-revm 15.0.0",
- "revm 34.0.0",
+ "op-alloy-consensus 2.0.0",
+ "op-revm 20.0.0",
+ "revm 38.0.0",
 ]
 
 [[package]]
 name = "hokulea-compute-proof"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "ark-bn254",
  "ark-serialize 0.5.0",
  "hokulea-proof",
@@ -4503,8 +4996,8 @@ dependencies = [
 name = "hokulea-eigenda"
 version = "0.1.0"
 dependencies = [
- "alloy-consensus",
- "alloy-primitives 1.5.6",
+ "alloy-consensus 2.0.4",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "async-trait",
  "eigenda-cert",
@@ -4523,9 +5016,9 @@ dependencies = [
 name = "hokulea-example-preloader"
 version = "0.1.0"
 dependencies = [
- "alloy-evm 0.27.3",
+ "alloy-evm 0.34.0",
  "alloy-op-evm",
- "alloy-rpc-client",
+ "alloy-rpc-client 1.6.3",
  "anyhow",
  "canoe-provider",
  "canoe-sp1-cc-host",
@@ -4542,11 +5035,12 @@ dependencies = [
  "hokulea-witgen",
  "hokulea-zkvm-verification",
  "kona-client",
+ "kona-genesis",
  "kona-preimage",
  "kona-proof",
- "op-alloy-consensus 0.23.1",
- "op-revm 15.0.0",
- "revm 34.0.0",
+ "op-alloy-consensus 2.0.0",
+ "op-revm 20.0.0",
+ "revm 38.0.0",
  "serde_json",
  "sp1-sdk",
  "tokio",
@@ -4557,7 +5051,8 @@ dependencies = [
 name = "hokulea-host-bin"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-op-evm",
+ "alloy-primitives 1.6.0",
  "anyhow",
  "async-trait",
  "clap",
@@ -4571,7 +5066,7 @@ dependencies = [
  "kona-preimage",
  "kona-proof",
  "kona-std-fpvm",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "thiserror 2.0.18",
  "tokio",
@@ -4583,7 +5078,7 @@ dependencies = [
 name = "hokulea-proof"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "ark-bn254",
  "ark-ff 0.5.0",
  "async-trait",
@@ -4610,7 +5105,7 @@ dependencies = [
 name = "hokulea-registry"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "canoe-verifier-address-fetcher",
  "eigenda-cert",
 ]
@@ -4619,7 +5114,7 @@ dependencies = [
 name = "hokulea-sp1-bn-verifier"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "ark-bn254",
  "ark-ff 0.5.0",
  "eigenda-cert",
@@ -4639,8 +5134,8 @@ dependencies = [
 name = "hokulea-witgen"
 version = "0.1.0"
 dependencies = [
- "alloy-consensus",
- "alloy-primitives 1.5.6",
+ "alloy-consensus 2.0.4",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "anyhow",
  "async-trait",
@@ -4732,6 +5227,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -4859,7 +5363,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -5172,6 +5676,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "simd_cesu8",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5204,6 +5757,24 @@ dependencies = [
  "serde",
  "serde_json",
  "simple_asn1",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "10.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+dependencies = [
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "getrandom 0.2.17",
+ "js-sys",
+ "pem",
+ "serde",
+ "serde_json",
+ "signature 2.2.0",
+ "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -5253,7 +5824,17 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -5269,10 +5850,10 @@ dependencies = [
 [[package]]
 name = "kona-cli"
 version = "0.3.2"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.14#3fd820798c94692dd97a3a48aa154c63bcbee45d"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "alloy-chains",
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "clap",
  "kona-genesis",
  "kona-registry",
@@ -5289,15 +5870,15 @@ dependencies = [
 [[package]]
 name = "kona-client"
 version = "1.0.2"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.14#3fd820798c94692dd97a3a48aa154c63bcbee45d"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-evm 0.27.3",
+ "alloy-consensus 2.0.4",
+ "alloy-eips 2.0.5",
+ "alloy-evm 0.34.0",
  "alloy-op-evm",
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
- "alloy-rpc-types-engine",
+ "alloy-rpc-types-engine 2.0.4",
  "async-trait",
  "cfg-if",
  "kona-derive",
@@ -5314,10 +5895,10 @@ dependencies = [
  "kona-std-fpvm",
  "kona-std-fpvm-proc",
  "lru 0.16.3",
- "op-alloy-consensus 0.23.1",
- "op-alloy-rpc-types-engine 0.23.1",
- "op-revm 15.0.0",
- "revm 34.0.0",
+ "op-alloy-consensus 2.0.0",
+ "op-alloy-rpc-types-engine 2.0.0",
+ "op-revm 20.0.0",
+ "revm 38.0.0",
  "serde",
  "serde_json",
  "spin 0.10.0",
@@ -5328,20 +5909,21 @@ dependencies = [
 [[package]]
 name = "kona-derive"
 version = "0.4.5"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.14#3fd820798c94692dd97a3a48aa154c63bcbee45d"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives 1.5.6",
+ "alloy-consensus 2.0.4",
+ "alloy-eips 2.0.5",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
- "alloy-rpc-types-engine",
+ "alloy-rpc-types-engine 2.0.4",
  "async-trait",
  "kona-genesis",
  "kona-hardforks",
+ "kona-interop",
  "kona-macros",
  "kona-protocol",
- "op-alloy-consensus 0.23.1",
- "op-alloy-rpc-types-engine 0.23.1",
+ "op-alloy-consensus 2.0.0",
+ "op-alloy-rpc-types-engine 2.0.0",
  "spin 0.10.0",
  "thiserror 2.0.18",
  "tracing",
@@ -5351,19 +5933,19 @@ dependencies = [
 [[package]]
 name = "kona-driver"
 version = "0.4.0"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.14#3fd820798c94692dd97a3a48aa154c63bcbee45d"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
- "alloy-consensus",
- "alloy-evm 0.27.3",
- "alloy-primitives 1.5.6",
+ "alloy-consensus 2.0.4",
+ "alloy-evm 0.34.0",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "async-trait",
  "kona-derive",
  "kona-executor",
  "kona-genesis",
  "kona-protocol",
- "op-alloy-consensus 0.23.1",
- "op-alloy-rpc-types-engine 0.23.1",
+ "op-alloy-consensus 2.0.0",
+ "op-alloy-rpc-types-engine 2.0.0",
  "spin 0.10.0",
  "thiserror 2.0.18",
  "tracing",
@@ -5372,23 +5954,23 @@ dependencies = [
 [[package]]
 name = "kona-executor"
 version = "0.4.0"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.14#3fd820798c94692dd97a3a48aa154c63bcbee45d"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-evm 0.27.3",
+ "alloy-consensus 2.0.4",
+ "alloy-eips 2.0.5",
+ "alloy-evm 0.34.0",
  "alloy-op-evm",
  "alloy-op-hardforks",
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "alloy-trie 0.9.4",
  "kona-genesis",
  "kona-mpt",
  "kona-protocol",
- "op-alloy-consensus 0.23.1",
- "op-alloy-rpc-types-engine 0.23.1",
- "op-revm 15.0.0",
- "revm 34.0.0",
+ "op-alloy-consensus 2.0.0",
+ "op-alloy-rpc-types-engine 2.0.0",
+ "op-revm 20.0.0",
+ "revm 38.0.0",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -5396,18 +5978,18 @@ dependencies = [
 [[package]]
 name = "kona-genesis"
 version = "0.4.5"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.14#3fd820798c94692dd97a3a48aa154c63bcbee45d"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "alloy-chains",
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
+ "alloy-consensus 2.0.4",
+ "alloy-eips 2.0.5",
+ "alloy-genesis 2.0.4",
  "alloy-hardforks 0.4.7",
  "alloy-op-hardforks",
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "alloy-sol-types",
  "derive_more 2.1.1",
- "op-revm 15.0.0",
+ "op-revm 20.0.0",
  "serde",
  "serde_repr",
  "tabled",
@@ -5417,31 +5999,35 @@ dependencies = [
 [[package]]
 name = "kona-hardforks"
 version = "0.4.5"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.14#3fd820798c94692dd97a3a48aa154c63bcbee45d"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
- "alloy-eips",
- "alloy-primitives 1.5.6",
+ "alloy-eips 2.0.5",
+ "alloy-primitives 1.6.0",
+ "anyhow",
  "kona-protocol",
- "op-alloy-consensus 0.23.1",
+ "once_cell",
+ "op-alloy-consensus 2.0.0",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "kona-host"
 version = "1.0.2"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.14#3fd820798c94692dd97a3a48aa154c63bcbee45d"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.4",
+ "alloy-eips 2.0.5",
  "alloy-op-evm",
- "alloy-primitives 1.5.6",
- "alloy-provider",
+ "alloy-primitives 1.6.0",
+ "alloy-provider 2.0.4",
  "alloy-rlp",
- "alloy-rpc-client",
- "alloy-rpc-types",
+ "alloy-rpc-client 2.0.4",
+ "alloy-rpc-types 2.0.4",
  "alloy-rpc-types-beacon",
- "alloy-serde",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-serde 2.0.5",
+ "alloy-transport 2.0.5",
+ "alloy-transport-http 2.0.4",
  "anyhow",
  "ark-ff 0.5.0",
  "async-trait",
@@ -5452,6 +6038,7 @@ dependencies = [
  "kona-driver",
  "kona-executor",
  "kona-genesis",
+ "kona-interop",
  "kona-mpt",
  "kona-preimage",
  "kona-proof",
@@ -5461,12 +6048,13 @@ dependencies = [
  "kona-registry",
  "kona-std-fpvm",
  "op-alloy-network",
- "op-alloy-rpc-types-engine 0.23.1",
- "op-revm 15.0.0",
- "revm 34.0.0",
+ "op-alloy-rpc-types-engine 2.0.0",
+ "op-revm 20.0.0",
+ "revm 38.0.0",
  "rocksdb",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5476,20 +6064,20 @@ dependencies = [
 [[package]]
 name = "kona-interop"
 version = "0.4.5"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.14#3fd820798c94692dd97a3a48aa154c63bcbee45d"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives 1.5.6",
+ "alloy-consensus 2.0.4",
+ "alloy-eips 2.0.5",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "alloy-sol-types",
  "async-trait",
  "derive_more 2.1.1",
  "kona-genesis",
  "kona-protocol",
  "kona-registry",
- "op-alloy-consensus 0.23.1",
+ "op-alloy-consensus 2.0.0",
  "serde",
  "thiserror 2.0.18",
  "tracing",
@@ -5498,29 +6086,30 @@ dependencies = [
 [[package]]
 name = "kona-macros"
 version = "0.1.2"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.14#3fd820798c94692dd97a3a48aa154c63bcbee45d"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 
 [[package]]
 name = "kona-mpt"
 version = "0.3.0"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.14#3fd820798c94692dd97a3a48aa154c63bcbee45d"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "alloy-trie 0.9.4",
- "op-alloy-rpc-types-engine 0.23.1",
+ "op-alloy-rpc-types-engine 2.0.0",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "kona-preimage"
 version = "0.3.0"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.14#3fd820798c94692dd97a3a48aa154c63bcbee45d"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "async-channel",
  "async-trait",
  "serde",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -5528,13 +6117,13 @@ dependencies = [
 [[package]]
 name = "kona-proof"
 version = "0.3.0"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.14#3fd820798c94692dd97a3a48aa154c63bcbee45d"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-evm 0.27.3",
+ "alloy-consensus 2.0.4",
+ "alloy-eips 2.0.5",
+ "alloy-evm 0.34.0",
  "alloy-op-evm",
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "alloy-trie 0.9.4",
  "ark-bls12-381",
@@ -5544,15 +6133,16 @@ dependencies = [
  "kona-driver",
  "kona-executor",
  "kona-genesis",
+ "kona-interop",
  "kona-mpt",
  "kona-preimage",
  "kona-protocol",
  "kona-registry",
  "lazy_static",
  "lru 0.16.3",
- "op-alloy-consensus 0.23.1",
- "op-alloy-rpc-types-engine 0.23.1",
- "op-revm 15.0.0",
+ "op-alloy-consensus 2.0.0",
+ "op-alloy-rpc-types-engine 2.0.0",
+ "op-revm 20.0.0",
  "serde",
  "serde_json",
  "spin 0.10.0",
@@ -5564,15 +6154,15 @@ dependencies = [
 [[package]]
 name = "kona-proof-interop"
 version = "0.2.0"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.14#3fd820798c94692dd97a3a48aa154c63bcbee45d"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-evm 0.27.3",
+ "alloy-consensus 2.0.4",
+ "alloy-eips 2.0.5",
+ "alloy-evm 0.34.0",
  "alloy-op-evm",
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
- "alloy-rpc-types-engine",
+ "alloy-rpc-types-engine 2.0.4",
  "async-trait",
  "kona-executor",
  "kona-genesis",
@@ -5582,10 +6172,10 @@ dependencies = [
  "kona-proof",
  "kona-protocol",
  "kona-registry",
- "op-alloy-consensus 0.23.1",
- "op-alloy-rpc-types-engine 0.23.1",
- "op-revm 15.0.0",
- "revm 34.0.0",
+ "op-alloy-consensus 2.0.0",
+ "op-alloy-rpc-types-engine 2.0.0",
+ "op-revm 20.0.0",
+ "revm 38.0.0",
  "serde",
  "serde_json",
  "spin 0.10.0",
@@ -5596,26 +6186,26 @@ dependencies = [
 [[package]]
 name = "kona-protocol"
 version = "0.4.5"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.14#3fd820798c94692dd97a3a48aa154c63bcbee45d"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "alloc-no-stdlib",
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.4",
+ "alloy-eips 2.0.5",
  "alloy-hardforks 0.4.7",
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
- "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-engine 2.0.4",
+ "alloy-rpc-types-eth 2.0.4",
+ "alloy-serde 2.0.5",
  "ambassador",
  "async-trait",
  "brotli",
  "derive_more 2.1.1",
  "kona-genesis",
  "miniz_oxide 0.9.1",
- "op-alloy-consensus 0.23.1",
+ "op-alloy-consensus 2.0.0",
  "op-alloy-rpc-types",
- "op-alloy-rpc-types-engine 0.23.1",
+ "op-alloy-rpc-types-engine 2.0.0",
  "serde",
  "spin 0.10.0",
  "thiserror 2.0.18",
@@ -5627,28 +6217,30 @@ dependencies = [
 [[package]]
 name = "kona-providers-alloy"
 version = "0.3.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.14#3fd820798c94692dd97a3a48aa154c63bcbee45d"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives 1.5.6",
- "alloy-provider",
- "alloy-rpc-client",
+ "alloy-consensus 2.0.4",
+ "alloy-eips 2.0.5",
+ "alloy-primitives 1.6.0",
+ "alloy-provider 2.0.4",
+ "alloy-rpc-client 2.0.4",
  "alloy-rpc-types-beacon",
- "alloy-rpc-types-engine",
- "alloy-serde",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-rpc-types-engine 2.0.4",
+ "alloy-serde 2.0.5",
+ "alloy-transport 2.0.5",
+ "alloy-transport-http 2.0.4",
  "async-trait",
  "c-kzg",
  "http-body-util",
  "kona-derive",
  "kona-genesis",
+ "kona-interop",
  "kona-macros",
  "kona-protocol",
  "lru 0.16.3",
- "op-alloy-consensus 0.23.1",
+ "op-alloy-consensus 2.0.0",
  "op-alloy-network",
+ "reqwest 0.13.4",
  "serde",
  "thiserror 2.0.18",
  "tower 0.5.3",
@@ -5658,14 +6250,14 @@ dependencies = [
 [[package]]
 name = "kona-registry"
 version = "0.4.5"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.14#3fd820798c94692dd97a3a48aa154c63bcbee45d"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "alloy-chains",
- "alloy-eips",
- "alloy-genesis",
+ "alloy-eips 2.0.5",
+ "alloy-genesis 2.0.4",
  "alloy-hardforks 0.4.7",
  "alloy-op-hardforks",
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "kona-genesis",
  "lazy_static",
  "serde",
@@ -5677,7 +6269,7 @@ dependencies = [
 [[package]]
 name = "kona-std-fpvm"
 version = "0.2.0"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.14#3fd820798c94692dd97a3a48aa154c63bcbee45d"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "async-trait",
  "buddy_system_allocator",
@@ -5689,7 +6281,7 @@ dependencies = [
 [[package]]
 name = "kona-std-fpvm-proc"
 version = "0.2.0"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.14#3fd820798c94692dd97a3a48aa154c63bcbee45d"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "cfg-if",
  "kona-std-fpvm",
@@ -5943,9 +6535,9 @@ checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
 name = "macro-string"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
+checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6034,7 +6626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
  "byteorder",
- "keccak",
+ "keccak 0.1.6",
  "rand_core 0.6.4",
  "zeroize",
 ]
@@ -6164,7 +6756,17 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a53d79ba8304ac1c4f9eb3b9d281f21f7be9d4626f72ce7df4ad8fbde4f38a74"
 dependencies = [
- "modular-bitfield-impl",
+ "modular-bitfield-impl 0.11.2",
+ "static_assertions",
+]
+
+[[package]]
+name = "modular-bitfield"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2956e537fc68236d2aa048f55704f231cc93f1c4de42fe1ecb5bd7938061fc4a"
+dependencies = [
+ "modular-bitfield-impl 0.13.1",
  "static_assertions",
 ]
 
@@ -6177,6 +6779,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "modular-bitfield-impl"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b43b4fd69e3437618106f7754f34021b831a514f9e1a98ae863cabcd8d8dad"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -6555,14 +7168,14 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "op-alloy"
-version = "0.23.1"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.14#3fd820798c94692dd97a3a48aa154c63bcbee45d"
+version = "2.0.0"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
- "op-alloy-consensus 0.23.1",
+ "op-alloy-consensus 2.0.0",
  "op-alloy-network",
  "op-alloy-provider",
  "op-alloy-rpc-types",
- "op-alloy-rpc-types-engine 0.23.1",
+ "op-alloy-rpc-types-engine 2.0.0",
 ]
 
 [[package]]
@@ -6571,9 +7184,9 @@ version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9ade20c592484ba1ea538006e0454284174447a3adf9bb59fa99ed512f95493"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives 1.5.6",
+ "alloy-consensus 1.6.3",
+ "alloy-eips 1.6.3",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "derive_more 2.1.1",
  "thiserror 2.0.18",
@@ -6585,11 +7198,11 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726da827358a547be9f1e37c2a756b9e3729cb0350f43408164794b370cad8ae"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives 1.5.6",
+ "alloy-consensus 1.6.3",
+ "alloy-eips 1.6.3",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 1.6.3",
  "derive_more 2.1.1",
  "serde",
  "serde_with",
@@ -6598,17 +7211,20 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.23.1"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.14#3fd820798c94692dd97a3a48aa154c63bcbee45d"
+version = "2.0.0"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-network",
- "alloy-primitives 1.5.6",
+ "alloy-consensus 2.0.4",
+ "alloy-eips 2.0.5",
+ "alloy-network 2.0.4",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 2.0.4",
+ "alloy-serde 2.0.5",
+ "bytes",
  "derive_more 2.1.1",
+ "reth-codecs 0.3.2",
+ "reth-zstd-compressors 0.3.2",
  "serde",
  "serde_with",
  "thiserror 2.0.18",
@@ -6616,46 +7232,46 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-network"
-version = "0.23.1"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.14#3fd820798c94692dd97a3a48aa154c63bcbee45d"
+version = "2.0.0"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
- "alloy-consensus",
- "alloy-network",
- "alloy-primitives 1.5.6",
- "alloy-provider",
- "alloy-rpc-types-eth",
- "alloy-signer",
- "op-alloy-consensus 0.23.1",
+ "alloy-consensus 2.0.4",
+ "alloy-network 2.0.4",
+ "alloy-provider 2.0.4",
+ "alloy-rpc-types-eth 2.0.4",
+ "op-alloy-consensus 2.0.0",
  "op-alloy-rpc-types",
 ]
 
 [[package]]
 name = "op-alloy-provider"
-version = "0.23.1"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.14#3fd820798c94692dd97a3a48aa154c63bcbee45d"
+version = "2.0.0"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
- "alloy-network",
- "alloy-primitives 1.5.6",
- "alloy-provider",
- "alloy-rpc-types-engine",
- "alloy-transport",
+ "alloy-network 2.0.4",
+ "alloy-primitives 1.6.0",
+ "alloy-provider 2.0.4",
+ "alloy-rpc-types-engine 2.0.4",
+ "alloy-transport 2.0.5",
  "async-trait",
- "op-alloy-rpc-types-engine 0.23.1",
+ "op-alloy-rpc-types-engine 2.0.0",
 ]
 
 [[package]]
 name = "op-alloy-rpc-types"
-version = "0.23.1"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.14#3fd820798c94692dd97a3a48aa154c63bcbee45d"
+version = "2.0.0"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-network-primitives",
- "alloy-primitives 1.5.6",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-consensus 2.0.4",
+ "alloy-eips 2.0.5",
+ "alloy-network 2.0.4",
+ "alloy-network-primitives 2.0.4",
+ "alloy-primitives 1.6.0",
+ "alloy-rpc-types-eth 2.0.4",
+ "alloy-serde 2.0.5",
  "derive_more 2.1.1",
- "op-alloy-consensus 0.23.1",
+ "op-alloy-consensus 2.0.0",
+ "reth-rpc-traits",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -6667,14 +7283,14 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8f24b8cb66e4b33e6c9e508bf46b8ecafc92eadd0b93fedd306c0accb477657"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives 1.5.6",
+ "alloy-consensus 1.6.3",
+ "alloy-eips 1.6.3",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
- "alloy-rpc-types-engine",
+ "alloy-rpc-types-engine 1.6.3",
  "derive_more 2.1.1",
- "ethereum_ssz",
- "ethereum_ssz_derive",
+ "ethereum_ssz 0.9.1",
+ "ethereum_ssz_derive 0.9.1",
  "op-alloy-consensus 0.22.4",
  "snap",
  "thiserror 2.0.18",
@@ -6682,19 +7298,18 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.23.1"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.14#3fd820798c94692dd97a3a48aa154c63bcbee45d"
+version = "2.0.0"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives 1.5.6",
+ "alloy-consensus 2.0.4",
+ "alloy-eips 2.0.5",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
- "alloy-rpc-types-engine",
- "alloy-serde",
- "derive_more 2.1.1",
- "ethereum_ssz",
- "ethereum_ssz_derive",
- "op-alloy-consensus 0.23.1",
+ "alloy-rpc-types-engine 2.0.4",
+ "alloy-serde 2.0.5",
+ "ethereum_ssz 0.10.4",
+ "ethereum_ssz_derive 0.10.4",
+ "op-alloy-consensus 2.0.0",
  "serde",
  "sha2 0.10.9",
  "snap",
@@ -6725,12 +7340,11 @@ dependencies = [
 
 [[package]]
 name = "op-revm"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c92b75162c2ed1661849fa51683b11254a5b661798360a2c24be918edafd40"
+version = "20.0.0"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "auto_impl",
- "revm 34.0.0",
+ "revm 38.0.0",
  "serde",
 ]
 
@@ -7124,6 +7738,7 @@ dependencies = [
  "arrayvec",
  "bitvec",
  "byte-slice-cast",
+ "bytes",
  "const_format",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
@@ -7633,7 +8248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -7653,7 +8268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.115",
@@ -7722,7 +8337,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.36",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7735,6 +8350,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -7759,9 +8375,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8083,6 +8699,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "reqwest-middleware"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8091,7 +8745,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http 1.4.0",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "thiserror 1.0.69",
  "tower-service",
@@ -8103,18 +8757,37 @@ version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
 dependencies = [
  "alloy-chains",
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 1.6.3",
+ "alloy-eips 1.6.3",
  "alloy-evm 0.23.3",
- "alloy-genesis",
- "alloy-primitives 1.5.6",
+ "alloy-genesis 1.6.3",
+ "alloy-primitives 1.6.0",
  "alloy-trie 0.9.4",
  "auto_impl",
  "derive_more 2.1.1",
  "reth-ethereum-forks",
  "reth-network-peers",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.9.3",
  "serde_json",
+]
+
+[[package]]
+name = "reth-codecs"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee9f6a4b8f4992c030c82fb8c2dcc872349452009b4127055f678f7d5a3dea3"
+dependencies = [
+ "alloy-consensus 2.0.4",
+ "alloy-eips 2.0.5",
+ "alloy-genesis 2.0.4",
+ "alloy-primitives 1.6.0",
+ "alloy-trie 0.9.4",
+ "bytes",
+ "modular-bitfield 0.13.1",
+ "parity-scale-codec",
+ "reth-codecs-derive 0.3.2",
+ "reth-zstd-compressors 0.3.2",
+ "serde",
 ]
 
 [[package]]
@@ -8122,17 +8795,28 @@ name = "reth-codecs"
 version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives 1.5.6",
+ "alloy-consensus 1.6.3",
+ "alloy-eips 1.6.3",
+ "alloy-genesis 1.6.3",
+ "alloy-primitives 1.6.0",
  "alloy-trie 0.9.4",
  "bytes",
- "modular-bitfield",
+ "modular-bitfield 0.11.2",
  "op-alloy-consensus 0.22.4",
- "reth-codecs-derive",
- "reth-zstd-compressors",
+ "reth-codecs-derive 1.9.3",
+ "reth-zstd-compressors 1.9.3",
  "serde",
+]
+
+[[package]]
+name = "reth-codecs-derive"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07feedb2c0ec9ec76dd1210b7486904f139243dc9b264586994a6246955c1c73"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -8150,11 +8834,11 @@ name = "reth-consensus"
 version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
 dependencies = [
- "alloy-consensus",
- "alloy-primitives 1.5.6",
+ "alloy-consensus 1.6.3",
+ "alloy-primitives 1.6.0",
  "auto_impl",
  "reth-execution-types",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.9.3",
  "thiserror 2.0.18",
 ]
 
@@ -8163,11 +8847,11 @@ name = "reth-consensus-common"
 version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 1.6.3",
+ "alloy-eips 1.6.3",
  "reth-chainspec",
  "reth-consensus",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.9.3",
 ]
 
 [[package]]
@@ -8175,10 +8859,10 @@ name = "reth-db-models"
 version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
 dependencies = [
- "alloy-eips",
- "alloy-primitives 1.5.6",
+ "alloy-eips 1.6.3",
+ "alloy-primitives 1.6.0",
  "bytes",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.9.3",
  "serde",
 ]
 
@@ -8198,14 +8882,14 @@ name = "reth-ethereum-consensus"
 version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives 1.5.6",
+ "alloy-consensus 1.6.3",
+ "alloy-eips 1.6.3",
+ "alloy-primitives 1.6.0",
  "reth-chainspec",
  "reth-consensus",
  "reth-consensus-common",
  "reth-execution-types",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.9.3",
  "tracing",
 ]
 
@@ -8216,7 +8900,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea8
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks 0.4.7",
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "auto_impl",
  "once_cell",
  "rustc-hash",
@@ -8227,15 +8911,15 @@ name = "reth-ethereum-primitives"
 version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives 1.5.6",
+ "alloy-consensus 1.6.3",
+ "alloy-eips 1.6.3",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "reth-codecs",
- "reth-primitives-traits",
- "reth-zstd-compressors",
+ "alloy-rpc-types-eth 1.6.3",
+ "alloy-serde 1.6.3",
+ "reth-codecs 1.9.3",
+ "reth-primitives-traits 1.9.3",
+ "reth-zstd-compressors 1.9.3",
  "serde",
  "serde_with",
 ]
@@ -8245,16 +8929,16 @@ name = "reth-evm"
 version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 1.6.3",
+ "alloy-eips 1.6.3",
  "alloy-evm 0.23.3",
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "auto_impl",
  "derive_more 2.1.1",
  "futures-util",
  "reth-execution-errors",
  "reth-execution-types",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.9.3",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie-common",
@@ -8266,18 +8950,18 @@ name = "reth-evm-ethereum"
 version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 1.6.3",
+ "alloy-eips 1.6.3",
  "alloy-evm 0.23.3",
- "alloy-primitives 1.5.6",
- "alloy-rpc-types-engine",
+ "alloy-primitives 1.6.0",
+ "alloy-rpc-types-engine 1.6.3",
  "derive_more 2.1.1",
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.9.3",
  "reth-storage-errors",
  "revm 31.0.2",
 ]
@@ -8288,7 +8972,7 @@ version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
 dependencies = [
  "alloy-evm 0.23.3",
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "nybbles 0.4.8",
  "reth-storage-errors",
@@ -8300,13 +8984,13 @@ name = "reth-execution-types"
 version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 1.6.3",
+ "alloy-eips 1.6.3",
  "alloy-evm 0.23.3",
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "derive_more 2.1.1",
  "reth-ethereum-primitives",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.9.3",
  "reth-trie-common",
  "revm 31.0.2",
  "serde",
@@ -8318,7 +9002,7 @@ name = "reth-network-peers"
 version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "secp256k1 0.30.0",
  "serde_with",
@@ -8331,12 +9015,36 @@ name = "reth-primitives"
 version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 1.6.3",
  "once_cell",
  "reth-ethereum-forks",
  "reth-ethereum-primitives",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.9.3",
  "reth-static-file-types",
+]
+
+[[package]]
+name = "reth-primitives-traits"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83138080a41e35a6aa876410ca67231fb35da7e2ca494315d8b8be15e9ed9c0"
+dependencies = [
+ "alloy-consensus 2.0.4",
+ "alloy-eips 2.0.5",
+ "alloy-genesis 2.0.4",
+ "alloy-primitives 1.6.0",
+ "alloy-rlp",
+ "alloy-rpc-types-eth 2.0.4",
+ "alloy-trie 0.9.4",
+ "bytes",
+ "derive_more 2.1.1",
+ "once_cell",
+ "revm-bytecode 10.0.0",
+ "revm-primitives 23.0.0",
+ "revm-state 11.0.1",
+ "secp256k1 0.30.0",
+ "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8344,19 +9052,19 @@ name = "reth-primitives-traits"
 version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives 1.5.6",
+ "alloy-consensus 1.6.3",
+ "alloy-eips 1.6.3",
+ "alloy-genesis 1.6.3",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 1.6.3",
  "alloy-trie 0.9.4",
  "auto_impl",
  "bytes",
  "derive_more 2.1.1",
  "once_cell",
  "op-alloy-consensus 0.22.4",
- "reth-codecs",
+ "reth-codecs 1.9.3",
  "revm-bytecode 7.1.1",
  "revm-primitives 21.0.2",
  "revm-state 8.1.1",
@@ -8371,10 +9079,25 @@ name = "reth-prune-types"
 version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "derive_more 2.1.1",
  "serde",
  "strum",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-rpc-traits"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "706ca5cd7bc99bdf82d89f7f3215242a9f901128ab4c09bb88b0640a0cf40b77"
+dependencies = [
+ "alloy-consensus 2.0.4",
+ "alloy-network 2.0.4",
+ "alloy-primitives 1.6.0",
+ "alloy-rpc-types-eth 2.0.4",
+ "alloy-signer 2.0.5",
+ "reth-primitives-traits 0.3.2",
  "thiserror 2.0.18",
 ]
 
@@ -8383,7 +9106,7 @@ name = "reth-stages-types"
 version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "bytes",
  "reth-trie-common",
  "serde",
@@ -8394,7 +9117,7 @@ name = "reth-static-file-types"
 version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "derive_more 2.1.1",
  "serde",
  "strum",
@@ -8405,16 +9128,16 @@ name = "reth-storage-api"
 version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives 1.5.6",
- "alloy-rpc-types-engine",
+ "alloy-consensus 1.6.3",
+ "alloy-eips 1.6.3",
+ "alloy-primitives 1.6.0",
+ "alloy-rpc-types-engine 1.6.3",
  "auto_impl",
  "reth-chainspec",
  "reth-db-models",
  "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.9.3",
  "reth-prune-types",
  "reth-stages-types",
  "reth-storage-errors",
@@ -8427,11 +9150,11 @@ name = "reth-storage-errors"
 version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
 dependencies = [
- "alloy-eips",
- "alloy-primitives 1.5.6",
+ "alloy-eips 1.6.3",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "derive_more 2.1.1",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.9.3",
  "reth-prune-types",
  "reth-static-file-types",
  "revm-database-interface 8.0.5",
@@ -8443,15 +9166,15 @@ name = "reth-trie"
 version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives 1.5.6",
+ "alloy-consensus 1.6.3",
+ "alloy-eips 1.6.3",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "alloy-trie 0.9.4",
  "auto_impl",
  "itertools 0.14.0",
  "reth-execution-errors",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.9.3",
  "reth-stages-types",
  "reth-storage-errors",
  "reth-trie-common",
@@ -8465,11 +9188,11 @@ name = "reth-trie-common"
 version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
 dependencies = [
- "alloy-consensus",
- "alloy-primitives 1.5.6",
+ "alloy-consensus 1.6.3",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 1.6.3",
+ "alloy-serde 1.6.3",
  "alloy-trie 0.9.4",
  "arrayvec",
  "bytes",
@@ -8477,7 +9200,7 @@ dependencies = [
  "itertools 0.14.0",
  "nybbles 0.4.8",
  "rayon",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.9.3",
  "revm-database 9.0.6",
  "serde",
  "serde_with",
@@ -8488,15 +9211,24 @@ name = "reth-trie-sparse"
 version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "alloy-trie 0.9.4",
  "auto_impl",
  "reth-execution-errors",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.9.3",
  "reth-trie-common",
  "smallvec",
  "tracing",
+]
+
+[[package]]
+name = "reth-zstd-compressors"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a1f121117f149412446e92c5442d4a9722e04e7760ac3f62d518f4213634d9"
+dependencies = [
+ "zstd",
 ]
 
 [[package]]
@@ -8547,21 +9279,21 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "34.0.0"
+version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2aabdebaa535b3575231a88d72b642897ae8106cf6b0d12eafc6bfdf50abfc7"
+checksum = "91202d39dbe8e8d10e9e8f2b76c30da68ecd1d25be69ba6d853ad0d03a3a398a"
 dependencies = [
- "revm-bytecode 8.0.0",
- "revm-context 13.0.0",
- "revm-context-interface 14.0.0",
- "revm-database 10.0.0",
- "revm-database-interface 9.0.0",
- "revm-handler 15.0.0",
- "revm-inspector 15.0.0",
- "revm-interpreter 32.0.0",
- "revm-precompile 32.1.0",
- "revm-primitives 22.1.0",
- "revm-state 9.0.0",
+ "revm-bytecode 10.0.0",
+ "revm-context 16.0.1",
+ "revm-context-interface 17.0.1",
+ "revm-database 13.0.1",
+ "revm-database-interface 11.0.1",
+ "revm-handler 18.1.0",
+ "revm-inspector 19.0.0",
+ "revm-interpreter 35.0.1",
+ "revm-precompile 34.0.0",
+ "revm-primitives 23.0.0",
+ "revm-state 11.0.1",
 ]
 
 [[package]]
@@ -8590,13 +9322,13 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "8.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d1e5c1eaa44d39d537f668bc5c3409dc01e5c8be954da6c83370bbdf006457"
+checksum = "bdbb3a3d735efa94c91f2ef6bf20a35f99a77bc78f3e25bd758336901bdf9661"
 dependencies = [
  "bitvec",
  "phf 0.13.1",
- "revm-primitives 22.1.0",
+ "revm-primitives 23.0.0",
  "serde",
 ]
 
@@ -8636,18 +9368,18 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "13.0.0"
+version = "16.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "892ff3e6a566cf8d72ffb627fdced3becebbd9ba64089c25975b9b028af326a5"
+checksum = "c5f68d928d8b228e0faeb1c6ed75c4fde7d124f1ddf9119b67e7a0ad4041237d"
 dependencies = [
  "bitvec",
  "cfg-if",
  "derive-where",
- "revm-bytecode 8.0.0",
- "revm-context-interface 14.0.0",
- "revm-database-interface 9.0.0",
- "revm-primitives 22.1.0",
- "revm-state 9.0.0",
+ "revm-bytecode 10.0.0",
+ "revm-context-interface 17.0.1",
+ "revm-database-interface 11.0.1",
+ "revm-primitives 23.0.0",
+ "revm-state 11.0.1",
  "serde",
 ]
 
@@ -8685,17 +9417,17 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "14.0.0"
+version = "17.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f61cc6d23678c4840af895b19f8acfbbd546142ec8028b6526c53cc1c16c98"
+checksum = "1f3758e6167c4ba7a59a689c519a047edaefcd4c37d74f279b93ed87bc8aece4"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
  "auto_impl",
  "either",
- "revm-database-interface 9.0.0",
- "revm-primitives 22.1.0",
- "revm-state 9.0.0",
+ "revm-database-interface 11.0.1",
+ "revm-primitives 23.0.0",
+ "revm-state 11.0.1",
  "serde",
 ]
 
@@ -8705,7 +9437,7 @@ version = "7.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39a276ed142b4718dcf64bc9624f474373ed82ef20611025045c3fb23edbef9c"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 1.6.3",
  "revm-bytecode 6.2.2",
  "revm-database-interface 7.0.5",
  "revm-primitives 20.2.1",
@@ -8719,7 +9451,7 @@ version = "9.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "980d8d6bba78c5dd35b83abbb6585b0b902eb25ea4448ed7bfba6283b0337191"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 1.6.3",
  "revm-bytecode 7.1.1",
  "revm-database-interface 8.0.5",
  "revm-primitives 21.0.2",
@@ -8729,15 +9461,15 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "10.0.0"
+version = "13.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529528d0b05fe646be86223032c3e77aa8b05caa2a35447d538c55965956a511"
+checksum = "c281a1f11d3bcb8c0bba1199ed6bcb001d1aeb3d4fb366819e14f88723989a4e"
 dependencies = [
- "alloy-eips",
- "revm-bytecode 8.0.0",
- "revm-database-interface 9.0.0",
- "revm-primitives 22.1.0",
- "revm-state 9.0.0",
+ "alloy-eips 1.6.3",
+ "revm-bytecode 10.0.0",
+ "revm-database-interface 11.0.1",
+ "revm-primitives 23.0.0",
+ "revm-state 11.0.1",
  "serde",
 ]
 
@@ -8769,14 +9501,14 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "9.0.0"
+version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7bf93ac5b91347c057610c0d96e923db8c62807e03f036762d03e981feddc1d"
+checksum = "d89efb9832a4e3742bb4ded5f7fe5bf905e8860e69427d4dfec153484fc6d304"
 dependencies = [
  "auto_impl",
  "either",
- "revm-primitives 22.1.0",
- "revm-state 9.0.0",
+ "revm-primitives 23.0.0",
+ "revm-state 11.0.1",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -8821,20 +9553,20 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "15.0.0"
+version = "18.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cd0e43e815a85eded249df886c4badec869195e70cdd808a13cfca2794622d2"
+checksum = "783e903d6922b7f5f9a940d1bb229530502d2924b1aed9d5ca5a94ebf065d460"
 dependencies = [
  "auto_impl",
  "derive-where",
- "revm-bytecode 8.0.0",
- "revm-context 13.0.0",
- "revm-context-interface 14.0.0",
- "revm-database-interface 9.0.0",
- "revm-interpreter 32.0.0",
- "revm-precompile 32.1.0",
- "revm-primitives 22.1.0",
- "revm-state 9.0.0",
+ "revm-bytecode 10.0.0",
+ "revm-context 16.0.1",
+ "revm-context-interface 17.0.1",
+ "revm-database-interface 11.0.1",
+ "revm-interpreter 35.0.1",
+ "revm-precompile 34.0.0",
+ "revm-primitives 23.0.0",
+ "revm-state 11.0.1",
  "serde",
 ]
 
@@ -8876,18 +9608,18 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "15.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3ccad59db91ef93696536a0dbaf2f6f17cfe20d4d8843ae118edb7e97947ef"
+checksum = "8216ad58422090d0daa9eb430e0a081f7ad07e7fd30681dee71f8420c99624e0"
 dependencies = [
  "auto_impl",
  "either",
- "revm-context 13.0.0",
- "revm-database-interface 9.0.0",
- "revm-handler 15.0.0",
- "revm-interpreter 32.0.0",
- "revm-primitives 22.1.0",
- "revm-state 9.0.0",
+ "revm-context 16.0.1",
+ "revm-database-interface 11.0.1",
+ "revm-handler 18.1.0",
+ "revm-interpreter 35.0.1",
+ "revm-primitives 23.0.0",
+ "revm-state 11.0.1",
  "serde",
  "serde_json",
 ]
@@ -8919,14 +9651,14 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "32.0.0"
+version = "35.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11406408597bc249392d39295831c4b641b3a6f5c471a7c41104a7a1e3564c07"
+checksum = "1ece9f41b69658c15d748288a4dbdfc06a63f3ce93d983af440de3f1631dce6a"
 dependencies = [
- "revm-bytecode 8.0.0",
- "revm-context-interface 14.0.0",
- "revm-primitives 22.1.0",
- "revm-state 9.0.0",
+ "revm-bytecode 10.0.0",
+ "revm-context-interface 17.0.1",
+ "revm-primitives 23.0.0",
+ "revm-state 11.0.1",
  "serde",
 ]
 
@@ -8982,9 +9714,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "32.1.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2ec11f45deec71e4945e1809736bb20d454285f9167ab53c5159dae1deb603f"
+checksum = "a346a8cc6c8c39bd65306641c692191299c0a7b63d38810e39e8fe9b92378660"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -8998,7 +9730,8 @@ dependencies = [
  "cfg-if",
  "k256 0.13.4",
  "p256",
- "revm-primitives 22.1.0",
+ "revm-context-interface 17.0.1",
+ "revm-primitives 23.0.0",
  "ripemd",
  "secp256k1 0.31.1",
  "sha2 0.10.9",
@@ -9010,7 +9743,7 @@ version = "20.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa29d9da06fe03b249b6419b33968ecdf92ad6428e2f012dc57bcd619b5d94e"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "num_enum 0.7.5",
  "once_cell",
  "serde",
@@ -9022,7 +9755,7 @@ version = "21.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29e161db429d465c09ba9cbff0df49e31049fe6b549e28eb0b7bd642fcbd4412"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "num_enum 0.7.5",
  "once_cell",
  "serde",
@@ -9030,11 +9763,11 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "22.1.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfb5ce6cf18b118932bcdb7da05cd9c250f2cb9f64131396b55f3fe3537c35"
+checksum = "0c99bda77d9661521ba0b4bc04558c6692074f01e65dd420fa3b893033d9b8a2"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "num_enum 0.7.5",
  "once_cell",
  "serde",
@@ -9066,14 +9799,14 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "9.0.0"
+version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311720d4f0f239b041375e7ddafdbd20032a33b7bae718562ea188e188ed9fd3"
+checksum = "c32490ed687dba31c3c882beb8c20408bdd30ef96690d8f145b0ee9a87040bfe"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.11.0",
- "revm-bytecode 8.0.0",
- "revm-primitives 22.1.0",
+ "revm-bytecode 10.0.0",
+ "revm-primitives 23.0.0",
  "serde",
 ]
 
@@ -9108,7 +9841,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -9263,12 +9996,12 @@ version = "2.4.0"
 source = "git+https://github.com/boundless-xyz/steel.git?tag=v2.4.0#44024df785e70a21a654689f8a00e387613c6eeb"
 dependencies = [
  "alloy",
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 1.6.3",
+ "alloy-eips 1.6.3",
  "alloy-evm 0.20.1",
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
- "alloy-rpc-types",
+ "alloy-rpc-types 1.6.3",
  "alloy-sol-types",
  "alloy-trie 0.8.1",
  "anyhow",
@@ -9492,11 +10225,11 @@ name = "rsp-client-executor"
 version = "0.1.0"
 source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.9.3-sp1-6.1.0#ed8416af24a289ed7aa23de402350090465ec97b"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 1.6.3",
  "alloy-evm 0.23.3",
- "alloy-network",
- "alloy-primitives 1.5.6",
- "alloy-rpc-types",
+ "alloy-network 1.6.3",
+ "alloy-primitives 1.6.0",
+ "alloy-rpc-types 1.6.3",
  "itertools 0.13.0",
  "kzg-rs",
  "reth-chainspec",
@@ -9508,7 +10241,7 @@ dependencies = [
  "reth-evm",
  "reth-evm-ethereum",
  "reth-execution-types",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.9.3",
  "reth-trie",
  "revm 31.0.2",
  "revm-primitives 21.0.2",
@@ -9525,10 +10258,10 @@ name = "rsp-mpt"
 version = "0.1.0"
 source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.9.3-sp1-6.1.0#ed8416af24a289ed7aa23de402350090465ec97b"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
- "alloy-rpc-types",
- "alloy-rpc-types-debug",
+ "alloy-rpc-types 1.6.3",
+ "alloy-rpc-types-debug 1.6.3",
  "reth-trie",
  "rlp",
  "serde",
@@ -9540,11 +10273,11 @@ name = "rsp-primitives"
 version = "0.1.0"
 source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.9.3-sp1-6.1.0#ed8416af24a289ed7aa23de402350090465ec97b"
 dependencies = [
- "alloy-eips",
- "alloy-genesis",
- "alloy-rpc-types",
+ "alloy-eips 1.6.3",
+ "alloy-genesis 1.6.3",
+ "alloy-rpc-types 1.6.3",
  "reth-chainspec",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.9.3",
  "reth-trie",
  "serde",
  "serde_json",
@@ -9557,11 +10290,11 @@ name = "rsp-rpc-db"
 version = "0.1.0"
 source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.9.3-sp1-6.1.0#ed8416af24a289ed7aa23de402350090465ec97b"
 dependencies = [
- "alloy-consensus",
- "alloy-primitives 1.5.6",
- "alloy-provider",
+ "alloy-consensus 1.6.3",
+ "alloy-primitives 1.6.0",
+ "alloy-provider 1.6.3",
  "alloy-rlp",
- "alloy-transport",
+ "alloy-transport 1.6.3",
  "alloy-trie 0.9.4",
  "async-trait",
  "reth-storage-errors",
@@ -9581,7 +10314,7 @@ name = "rsp-witness-db"
 version = "0.1.0"
 source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.9.3-sp1-6.1.0#ed8416af24a289ed7aa23de402350090465ec97b"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "reth-storage-errors",
  "revm-database-interface 8.0.5",
  "revm-primitives 21.0.2",
@@ -9730,7 +10463,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9793,13 +10526,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.36",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.9",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -9811,7 +10571,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -9855,6 +10615,15 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 0.8.23",
  "yaml-rust2",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -9936,7 +10705,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -10263,7 +11032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -10281,7 +11050,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -10293,7 +11062,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -10304,7 +11073,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
- "keccak",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.0",
 ]
 
 [[package]]
@@ -10360,6 +11139,16 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version 0.4.1",
+ "simdutf8",
 ]
 
 [[package]]
@@ -10899,13 +11688,13 @@ name = "sp1-cc-client-executor"
 version = "0.1.0"
 source = "git+https://github.com/succinctlabs/sp1-contract-call.git?tag=reth-1.9.3-sp1-6.1.0#1c81fc48fa367eaae2f46c852cc5276399bacf26"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 1.6.3",
+ "alloy-eips 1.6.3",
  "alloy-evm 0.23.3",
- "alloy-primitives 1.5.6",
- "alloy-rpc-types",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-primitives 1.6.0",
+ "alloy-rpc-types 1.6.3",
+ "alloy-rpc-types-eth 1.6.3",
+ "alloy-serde 1.6.3",
  "alloy-sol-types",
  "alloy-trie 0.9.4",
  "eyre",
@@ -10933,20 +11722,20 @@ name = "sp1-cc-host-executor"
 version = "0.1.0"
 source = "git+https://github.com/succinctlabs/sp1-contract-call.git?tag=reth-1.9.3-sp1-6.1.0#1c81fc48fa367eaae2f46c852cc5276399bacf26"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 1.6.3",
+ "alloy-eips 1.6.3",
  "alloy-evm 0.23.3",
- "alloy-primitives 1.5.6",
- "alloy-provider",
- "alloy-rpc-client",
- "alloy-rpc-types",
+ "alloy-primitives 1.6.0",
+ "alloy-provider 1.6.3",
+ "alloy-rpc-client 1.6.3",
+ "alloy-rpc-types 1.6.3",
  "alloy-sol-macro",
  "alloy-sol-types",
- "alloy-transport",
+ "alloy-transport 1.6.3",
  "async-trait",
  "ethereum-consensus 0.1.1 (git+https://github.com/succinctlabs/ethereum-consensus?branch=dev)",
  "eyre",
- "reqwest",
+ "reqwest 0.12.28",
  "reth-chainspec",
  "reth-primitives",
  "revm 31.0.2",
@@ -11245,7 +12034,7 @@ dependencies = [
  "opentelemetry",
  "pin-project",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serial_test",
@@ -11444,8 +12233,8 @@ version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349ca86c7a88456c9f0fa1c8869e0d35bb63d6c811dc9ad8337c90909ce532ec"
 dependencies = [
- "alloy-primitives 1.5.6",
- "alloy-signer",
+ "alloy-primitives 1.6.0",
+ "alloy-signer 1.6.3",
  "alloy-signer-aws",
  "alloy-signer-local",
  "anyhow",
@@ -11464,7 +12253,7 @@ dependencies = [
  "k256 0.13.4",
  "num-bigint 0.4.6",
  "prost",
- "reqwest",
+ "reqwest 0.12.28",
  "reqwest-middleware",
  "rustls 0.23.36",
  "serde",
@@ -11590,7 +12379,7 @@ name = "ssz_rs"
 version = "0.9.0"
 source = "git+https://github.com/succinctlabs/ssz-rs?branch=dev#f7266620b524389bd92c4e6be875e2a884eb6ac0"
 dependencies = [
- "alloy-primitives 1.5.6",
+ "alloy-primitives 1.6.0",
  "bitvec",
  "serde",
  "sha2 0.9.9",
@@ -11784,9 +12573,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8658017776544996edc21c8c7cc8bb4f13db60955382f4bac25dc6303b38438"
+checksum = "ec005042c7d952febc1a3ef5b0f6674e9054aa836877a31c90b20e25b3d31744"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -11902,7 +12691,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12115,9 +12904,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
@@ -12175,7 +12964,7 @@ dependencies = [
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -12207,7 +12996,7 @@ dependencies = [
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -12219,7 +13008,7 @@ dependencies = [
  "indexmap 2.13.0",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -12228,7 +13017,7 @@ version = "1.0.8+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0742ff5ff03ea7e67c8ae6c93cac239e0d9784833362da3f9a9c1da8dfefcbdc"
 dependencies = [
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -12484,9 +13273,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -12514,7 +13303,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.8.1",
  "prost",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -12609,6 +13398,12 @@ name = "unsigned-varint"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -12707,6 +13502,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -12883,6 +13688,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12921,6 +13735,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -13309,6 +14132,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13596,7 +14428,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "sha2 0.10.9",
- "sha3",
+ "sha3 0.10.8",
  "subtle",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,18 +28,18 @@ codegen-units = 1
 lto = "fat"
 
 [workspace.dependencies]
-kona-client = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
-kona-host = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
-kona-derive = { version = "0.4.5", git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
-kona-driver = { version = "0.4.0", git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
-kona-executor = { version = "0.4.0", git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
-kona-preimage = { version = "0.3.0", git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
-kona-proof = { version = "0.3.0", git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
-kona-std-fpvm = { version = "0.2.0", git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
-kona-std-fpvm-proc = { version = "0.2.0", git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
-kona-genesis = { version = "0.4.5", git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
-kona-protocol = { version = "0.4.5", git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
-kona-cli = { version = "0.3.2", git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
+kona-client = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.5.2", default-features = false }
+kona-host = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.5.2", default-features = false }
+kona-derive = { version = "0.4.5", git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.5.2", default-features = false }
+kona-driver = { version = "0.4.0", git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.5.2", default-features = false }
+kona-executor = { version = "0.4.0", git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.5.2", default-features = false }
+kona-preimage = { version = "0.3.0", git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.5.2", default-features = false }
+kona-proof = { version = "0.3.0", git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.5.2", default-features = false }
+kona-std-fpvm = { version = "0.2.0", git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.5.2", default-features = false }
+kona-std-fpvm-proc = { version = "0.2.0", git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.5.2", default-features = false }
+kona-genesis = { version = "0.4.5", git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.5.2", default-features = false }
+kona-protocol = { version = "0.4.5", git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.5.2", default-features = false }
+kona-cli = { version = "0.3.2", git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.5.2", default-features = false }
 
 # Workspace
 hokulea-host-bin = { path = "bin/host", version = "0.1.0", default-features = false }
@@ -57,24 +57,24 @@ hokulea-sp1-bn-verifier = { path = "crates/sp1-bn-verifier", version = "0.1.0", 
 eigenda-cert = { path = "crates/eigenda-cert" }
 
 # Alloy (Network)
-alloy-consensus = { version = "=1.6.3", default-features = false }
-alloy-genesis = { version = "=1.6.3", default-features = false }
+alloy-consensus = { version = "=2.0.4", default-features = false }
+alloy-genesis = { version = "=2.0.4", default-features = false }
 alloy-primitives = { version = "1.5.6", default-features = false }
-alloy-provider = { version = "=1.6.3", default-features = false }
+alloy-provider = { version = "=2.0.4", default-features = false }
 alloy-rlp = { version = "0.3.13", default-features = false }
-alloy-rpc-client = { version = "=1.6.3", default-features = false }
-alloy-rpc-types = { version = "=1.6.3", default-features = false }
+alloy-rpc-client = { version = "=2.0.4", default-features = false }
+alloy-rpc-types = { version = "=2.0.4", default-features = false }
 alloy-sol-types = { version = "1.5.6", default-features = false }
 
 # Execution
-alloy-evm = { version = "0.27.2", default-features = false }
-alloy-op-evm = { version = "0.26.3", default-features = false }
-op-revm = { version = "15.0.0", default-features = false }
-revm = { version = "34.0.0", default-features = false }
-revm-primitives = { version = "21.0.2", default-features = false }
+alloy-evm = { version = "0.34.0", default-features = false }
+alloy-op-evm = { version = "0.32.0", default-features = false }
+op-revm = { version = "20.0.0", default-features = false }
+revm = { version = "38.0.0", default-features = false }
+revm-primitives = { version = "23.0.0", default-features = false }
 
 # OP Alloy
-op-alloy-consensus = { version = "=0.23.1", default-features = false }
+op-alloy-consensus = { version = "=2.0.0", default-features = false }
 
 # Reth
 reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3", default-features = false }
@@ -150,11 +150,12 @@ hex = "0.4"
 url = { version = "2.5.4" }
 
 [patch.crates-io]
-op-alloy-consensus = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14" }
-op-alloy-network = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14" }
-op-alloy-rpc-types = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14" }
-op-alloy-rpc-types-engine = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14" }
-op-alloy-provider = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14" }
-alloy-op-evm = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14" }
-alloy-op-hardforks = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14" }
-op-alloy = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14" }
+op-alloy-consensus = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.5.2" }
+op-alloy-network = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.5.2" }
+op-alloy-rpc-types = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.5.2" }
+op-alloy-rpc-types-engine = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.5.2" }
+op-alloy-provider = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.5.2" }
+alloy-op-evm = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.5.2" }
+alloy-op-hardforks = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.5.2" }
+op-alloy = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.5.2" }
+op-revm = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.5.2" }

--- a/bin/client/Cargo.toml
+++ b/bin/client/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 kona-client.workspace = true
 kona-preimage.workspace = true
 kona-proof.workspace = true
+kona-genesis.workspace = true
 kona-std-fpvm.workspace = true
 kona-std-fpvm-proc.workspace = true
 

--- a/bin/client/src/client.rs
+++ b/bin/client/src/client.rs
@@ -4,15 +4,19 @@ use alloc::sync::Arc;
 use core::fmt::Debug;
 
 use kona_client::single::FaultProofProgramError;
+use kona_genesis::RollupConfig;
 use kona_preimage::{HintWriterClient, PreimageOracleClient};
 use kona_proof::{l1::OracleBlobProvider, CachingOracle};
 
 use hokulea_client::fp_client;
 use hokulea_proof::eigenda_provider::OracleEigenDAPreimageProvider;
 
-use alloy_evm::{EvmFactory, FromRecoveredTx, FromTxWithEncoded};
-use alloy_op_evm::block::OpTxEnv;
-use op_alloy_consensus::OpTxEnvelope;
+use alloy_evm::{block::BlockExecutorFactory, EvmFactory, FromRecoveredTx, FromTxWithEncoded};
+use alloy_op_evm::{
+    block::{OpAlloyReceiptBuilder, OpTxEnv},
+    OpBlockExecutionCtx, OpBlockExecutorFactory,
+};
+use op_alloy_consensus::{OpReceiptEnvelope, OpTxEnvelope};
 use op_revm::OpSpecId;
 use revm::context::BlockEnv;
 
@@ -31,6 +35,12 @@ where
     Evm: EvmFactory<Spec = OpSpecId, BlockEnv = BlockEnv> + Send + Sync + Debug + Clone + 'static,
     <Evm as EvmFactory>::Tx:
         FromTxWithEncoded<OpTxEnvelope> + FromRecoveredTx<OpTxEnvelope> + OpTxEnv,
+    OpBlockExecutorFactory<OpAlloyReceiptBuilder, RollupConfig, Evm>: for<'a> BlockExecutorFactory<
+        EvmFactory = Evm,
+        ExecutionCtx<'a> = OpBlockExecutionCtx,
+        Transaction = OpTxEnvelope,
+        Receipt = OpReceiptEnvelope,
+    >,
 {
     const ORACLE_LRU_SIZE: usize = 1024;
 

--- a/bin/client/src/main.rs
+++ b/bin/client/src/main.rs
@@ -9,6 +9,7 @@ use kona_preimage::{HintWriter, OracleReader};
 use kona_std_fpvm::{FileChannel, FileDescriptor};
 use kona_std_fpvm_proc::client_entry;
 
+use alloy_op_evm::post_exec::PostExecEvmFactoryAdapter;
 use kona_client::fpvm_evm::FpvmOpEvmFactory;
 
 /// The global preimage oracle reader pipe.
@@ -30,6 +31,6 @@ fn main() -> Result<(), String> {
     kona_proof::block_on(run_direct_client(
         ORACLE_READER,
         HINT_WRITER,
-        FpvmOpEvmFactory::new(HINT_WRITER, ORACLE_READER),
+        PostExecEvmFactoryAdapter::new(FpvmOpEvmFactory::new(HINT_WRITER, ORACLE_READER)),
     ))
 }

--- a/bin/host/Cargo.toml
+++ b/bin/host/Cargo.toml
@@ -20,6 +20,7 @@ kona-client.workspace = true
 
 # Alloy
 alloy-primitives = { workspace = true, features = ["serde"] }
+alloy-op-evm.workspace = true
 
 # General
 anyhow.workspace = true

--- a/bin/host/src/cfg.rs
+++ b/bin/host/src/cfg.rs
@@ -1,5 +1,6 @@
 use crate::eigenda_preimage::OnlineEigenDAPreimageProvider;
 use crate::handler::SingleChainHintHandlerWithEigenDA;
+use alloy_op_evm::post_exec::PostExecEvmFactoryAdapter;
 use anyhow::Result;
 use clap::Parser;
 use hokulea_proof::hint::ExtendedHintType;
@@ -144,10 +145,10 @@ impl SingleChainHostWithEigenDA {
         let client_task = task::spawn(hokulea_client_bin::client::run_direct_client(
             OracleReader::new(preimage.client.clone()),
             HintWriter::new(hint.client.clone()),
-            FpvmOpEvmFactory::new(
+            PostExecEvmFactoryAdapter::new(FpvmOpEvmFactory::new(
                 HintWriter::new(hint.client),
                 OracleReader::new(preimage.client),
-            ),
+            )),
         ));
 
         let (_, client_result) = tokio::try_join!(server_task, client_task)?;

--- a/canoe/sp1-cc/host/Cargo.toml
+++ b/canoe/sp1-cc/host/Cargo.toml
@@ -7,10 +7,13 @@ edition = "2021"
 sp1-cc-client-executor.workspace = true
 sp1-cc-host-executor.workspace = true
 
-alloy-genesis.workspace = true
+# sp1-cc runs on the reth-1.9.3 / alloy-1.x stack (sp1-cc tag reth-1.9.3-sp1-6.1.0),
+# so these alloy crates are pinned to the steel/sp1-compatible 1.6.x versions rather
+# than the workspace's alloy-2.x pins used on the Kona (L2) side.
+alloy-genesis = { version = "1.6.3", default-features = false }
 alloy-primitives.workspace = true
-alloy-rpc-client.workspace = true
-alloy-rpc-types.workspace = true
+alloy-rpc-client = { version = "1.6.3", default-features = false }
+alloy-rpc-types = { version = "1.6.3", default-features = false }
 alloy-sol-types.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true

--- a/canoe/verifier/Cargo.toml
+++ b/canoe/verifier/Cargo.toml
@@ -10,8 +10,12 @@ alloy-primitives = { workspace = true }
 serde.workspace = true
 thiserror.workspace = true
 
-revm-primitives = { workspace = true }
+# canoe verifies the EigenDA cert via an L1 view-call on the reth-1.9.3 / revm-31
+# stack (shared with risc0-steel and sp1-cc), which is alloy 1.x. These types must
+# match reth's, so they are pinned to the reth-compatible versions rather than the
+# workspace's alloy-2.x / revm-23 pins used on the Kona (L2) side.
+revm-primitives = { version = "21.0.2", default-features = false }
 reth-chainspec = { workspace = true }
 reth-evm = { workspace = true }
-alloy-genesis = { workspace = true }
+alloy-genesis = { version = "1.6.3", default-features = false }
 tracing = { workspace = true }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -19,6 +19,7 @@ kona-proof.workspace = true
 kona-driver.workspace = true
 kona-executor.workspace = true
 kona-derive.workspace = true
+kona-genesis.workspace = true
 
 hokulea-eigenda.workspace = true
 

--- a/crates/client/src/fp_client.rs
+++ b/crates/client/src/fp_client.rs
@@ -11,6 +11,7 @@ use kona_client::single::{fetch_safe_head_hash, FaultProofProgramError};
 use kona_derive::BlobProvider;
 use kona_driver::Driver;
 use kona_executor::TrieDBProvider;
+use kona_genesis::RollupConfig;
 use kona_preimage::CommsClient;
 use kona_proof::{
     executor::KonaExecutor, l1::OracleL1ChainProvider, l1::OraclePipeline,
@@ -19,9 +20,12 @@ use kona_proof::{
 
 use kona_derive::EthereumDataSource;
 
-use alloy_evm::{EvmFactory, FromRecoveredTx, FromTxWithEncoded};
-use alloy_op_evm::block::OpTxEnv;
-use op_alloy_consensus::OpTxEnvelope;
+use alloy_evm::{block::BlockExecutorFactory, EvmFactory, FromRecoveredTx, FromTxWithEncoded};
+use alloy_op_evm::{
+    block::{OpAlloyReceiptBuilder, OpTxEnv},
+    OpBlockExecutionCtx, OpBlockExecutorFactory,
+};
+use op_alloy_consensus::{OpReceiptEnvelope, OpTxEnvelope};
 use op_revm::OpSpecId;
 use revm::context::BlockEnv;
 
@@ -42,6 +46,12 @@ where
     <E as EigenDAPreimageProvider>::Error: Debug,
     <Evm as EvmFactory>::Tx:
         FromTxWithEncoded<OpTxEnvelope> + FromRecoveredTx<OpTxEnvelope> + OpTxEnv,
+    OpBlockExecutorFactory<OpAlloyReceiptBuilder, RollupConfig, Evm>: for<'a> BlockExecutorFactory<
+        EvmFactory = Evm,
+        ExecutionCtx<'a> = OpBlockExecutionCtx,
+        Transaction = OpTxEnvelope,
+        Receipt = OpReceiptEnvelope,
+    >,
 {
     ////////////////////////////////////////////////////////////////
     //                          PROLOGUE                          //
@@ -117,6 +127,7 @@ where
         dap,
         l1_provider.clone(),
         l2_provider.clone(),
+        None,
     )
     .await?;
 

--- a/example/preloader/Cargo.toml
+++ b/example/preloader/Cargo.toml
@@ -21,13 +21,17 @@ tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
 
 kona-client.workspace = true
+kona-genesis.workspace = true
 kona-preimage.workspace = true
 kona-proof.workspace = true
 
 # Execution
 alloy-evm.workspace = true
 alloy-op-evm.workspace = true
-alloy-rpc-client.workspace = true
+# Only the `sp1-cc` feature path uses this — to build the L1 RpcClient for
+# CanoeSp1CCReducedProofProvider, which lives on the reth-1.9.3 / alloy-1.x stack.
+# Pinned to 1.6.x rather than the workspace's alloy-2.x so the RpcClient types match.
+alloy-rpc-client = { version = "1.6.3", default-features = false }
 op-alloy-consensus.workspace = true
 op-revm.workspace = true
 revm.workspace = true

--- a/example/preloader/src/main.rs
+++ b/example/preloader/src/main.rs
@@ -5,6 +5,7 @@ use hokulea_host_bin::{cfg::SingleChainHostWithEigenDA, init_tracing_subscriber}
 use hokulea_zkvm_verification::eigenda_witness_to_preloaded_provider;
 use kona_client::fpvm_evm::FpvmOpEvmFactory;
 use kona_client::single::FaultProofProgramError;
+use kona_genesis::RollupConfig;
 use kona_preimage::{
     BidirectionalChannel, CommsClient, HintWriter, HintWriterClient, OracleReader,
     PreimageOracleClient,
@@ -14,9 +15,13 @@ use tokio::task;
 
 use core::fmt::Debug;
 
-use alloy_evm::{EvmFactory, FromRecoveredTx, FromTxWithEncoded};
-use alloy_op_evm::block::OpTxEnv;
-use op_alloy_consensus::OpTxEnvelope;
+use alloy_evm::{block::BlockExecutorFactory, EvmFactory, FromRecoveredTx, FromTxWithEncoded};
+use alloy_op_evm::{
+    block::{OpAlloyReceiptBuilder, OpTxEnv},
+    post_exec::PostExecEvmFactoryAdapter,
+    OpBlockExecutionCtx, OpBlockExecutorFactory,
+};
+use op_alloy_consensus::{OpReceiptEnvelope, OpTxEnvelope};
 use op_revm::OpSpecId;
 use revm::context::BlockEnv;
 
@@ -113,10 +118,10 @@ async fn main() -> anyhow::Result<()> {
     let client_task = task::spawn(run_witgen_and_zk_verification(
         OracleReader::new(preimage.client.clone()),
         HintWriter::new(hint.client.clone()),
-        FpvmOpEvmFactory::new(
+        PostExecEvmFactoryAdapter::new(FpvmOpEvmFactory::new(
             HintWriter::new(hint.client),
             OracleReader::new(preimage.client),
-        ),
+        )),
         canoe_provider,
         canoe_verifier,
         canoe_address_fetcher,
@@ -149,6 +154,12 @@ where
     Evm: EvmFactory<Spec = OpSpecId, BlockEnv = BlockEnv> + Send + Sync + Debug + Clone + 'static,
     <Evm as EvmFactory>::Tx:
         FromTxWithEncoded<OpTxEnvelope> + FromRecoveredTx<OpTxEnvelope> + OpTxEnv,
+    OpBlockExecutorFactory<OpAlloyReceiptBuilder, RollupConfig, Evm>: for<'a> BlockExecutorFactory<
+        EvmFactory = Evm,
+        ExecutionCtx<'a> = OpBlockExecutionCtx,
+        Transaction = OpTxEnvelope,
+        Receipt = OpReceiptEnvelope,
+    >,
 {
     const ORACLE_LRU_SIZE: usize = 1024;
 
@@ -195,6 +206,12 @@ where
     Evm: EvmFactory<Spec = OpSpecId, BlockEnv = BlockEnv> + Send + Sync + Debug + Clone + 'static,
     <Evm as EvmFactory>::Tx:
         FromTxWithEncoded<OpTxEnvelope> + FromRecoveredTx<OpTxEnvelope> + OpTxEnv,
+    OpBlockExecutorFactory<OpAlloyReceiptBuilder, RollupConfig, Evm>: for<'a> BlockExecutorFactory<
+        EvmFactory = Evm,
+        ExecutionCtx<'a> = OpBlockExecutionCtx,
+        Transaction = OpTxEnvelope,
+        Receipt = OpReceiptEnvelope,
+    >,
 {
     // Run derivation for the first time to populate the witness data
     let eigenda_preimage: EigenDAPreimage =
@@ -244,6 +261,12 @@ where
     Evm: EvmFactory<Spec = OpSpecId, BlockEnv = BlockEnv> + Send + Sync + Debug + Clone + 'static,
     <Evm as EvmFactory>::Tx:
         FromTxWithEncoded<OpTxEnvelope> + FromRecoveredTx<OpTxEnvelope> + OpTxEnv,
+    OpBlockExecutorFactory<OpAlloyReceiptBuilder, RollupConfig, Evm>: for<'a> BlockExecutorFactory<
+        EvmFactory = Evm,
+        ExecutionCtx<'a> = OpBlockExecutionCtx,
+        Transaction = OpTxEnvelope,
+        Receipt = OpReceiptEnvelope,
+    >,
 {
     let beacon = OracleBlobProvider::new(oracle.clone());
 
@@ -279,6 +302,12 @@ where
     Evm: EvmFactory<Spec = OpSpecId, BlockEnv = BlockEnv> + Send + Sync + Debug + Clone + 'static,
     <Evm as EvmFactory>::Tx:
         FromTxWithEncoded<OpTxEnvelope> + FromRecoveredTx<OpTxEnvelope> + OpTxEnv,
+    OpBlockExecutorFactory<OpAlloyReceiptBuilder, RollupConfig, Evm>: for<'a> BlockExecutorFactory<
+        EvmFactory = Evm,
+        ExecutionCtx<'a> = OpBlockExecutionCtx,
+        Transaction = OpTxEnvelope,
+        Receipt = OpReceiptEnvelope,
+    >,
 {
     info!("start the code supposed to run inside zkVM");
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = '1.92'
+channel = '1.94'
 profile = 'minimal'
 components = ['clippy', 'rustfmt']
 targets = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin", "i686-unknown-linux-gnu"]


### PR DESCRIPTION
This PR bumps the core kona import to the latest version. The asterisc and sp1 builds are deferred to future work.